### PR TITLE
Pacelaps by lap count

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,18 @@ This script is designed to trigger safety car events in iRacing at random interv
 
    # Start minute for possible safety car appearance
    # This is the earliest time a safety car can appear in the race, in minutes
-   start_minute = 5
+   start_minute = 5.0
 
    # End minute for possible safety car appearance
    # This is the latest time a safety car can appear in the race, in minutes
-   end_minute = 40
+   end_minute = 30.0
 
    # Minimum amount of time between safety car appearances
    # This is the minimum amount of time between safety car appearances, in minutes
-   min_time_between = 10
+   min_time_between = 10.0
+
+   # Number of laps behind safety car (including SC out lap, must be > 2)
+   laps = 2
    ```
 
    You can adjust these settings to your preferences.

--- a/main.py
+++ b/main.py
@@ -95,6 +95,9 @@ while True:
                 time.sleep(0.05)
                 pyautogui.press("enter")
                 break
+
+            # Wait 1 second before checking again
+            time.sleep(1)
         
     # Wait 1 second before checking again
     time.sleep(1)

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ max_sc = config.getint('settings', 'max_safety_cars')
 start_minute = config.getfloat('settings', 'start_minute')
 end_minute = config.getfloat('settings', 'end_minute')
 min_time_between = config.getfloat('settings', 'min_time_between')
-time_until_green = config.getfloat('settings', 'time_until_green')
+laps = config.getint('settings', 'laps')
 print("Loaded settings.")
 
 # Randomly determine number of safety car events
@@ -82,17 +82,19 @@ while True:
         # Remove the safety car event from the list
         sc_times.pop(0)
 
-        # Wait for the time until green flag
-        print(f"Waiting {time_until_green} minutes for green flag...")
-        time.sleep(time_until_green * 60)
+        # Get the max value from all cars' lap started count
+        lap_at_yellow = max(ir["CarIdxLap"])
 
-        # Send green flag chat command if still pacing
-        if ir["PaceMode"] == 2 or ir["PaceMode"] == 3:
-            ir.chat_command(1)
-            time.sleep(0.05)
-            pyautogui.write("!pacelaps 1", interval = 0.01)
-            time.sleep(0.05)
-            pyautogui.press("enter")
+        # Wait for 2 laps to be completed
+        while True:
+            if max(ir["CarIdxLap"]) >= lap_at_yellow + 2:
+                # Send the pacelaps chat command
+                ir.chat_command(1)
+                time.sleep(0.05)
+                pyautogui.write(f"!pacelaps {laps - 1}", interval = 0.01)
+                time.sleep(0.05)
+                pyautogui.press("enter")
+                break
         
     # Wait 1 second before checking again
     time.sleep(1)

--- a/settings.ini
+++ b/settings.ini
@@ -1,17 +1,17 @@
 [settings]
 # Minimum number of safety cars to appear during the race
-min_safety_cars = 0
+min_safety_cars = 1
 
 # Maximum number of safety cars to appear during the race
 max_safety_cars = 2
 
 # Start minute for possible safety car appearance
 # This is the earliest time a safety car can appear in the race, in minutes
-start_minute = 5.0
+start_minute = 0.5
 
 # End minute for possible safety car appearance
 # This is the latest time a safety car can appear in the race, in minutes
-end_minute = 35.0
+end_minute = 1.5
 
 # Minimum amount of time between safety car appearances
 # This is the minimum amount of time between safety car appearances, in minutes

--- a/settings.ini
+++ b/settings.ini
@@ -17,7 +17,5 @@ end_minute = 35.0
 # This is the minimum amount of time between safety car appearances, in minutes
 min_time_between = 10.0
 
-# Amount of time until 1 to green
-# This is the amount of time until 1 to green is called, in minutes
-# NOTE: If this is too short and the SC hasn't gone around once yet, the command will be rejected!
-time_until_green = 5.0
+# Number of laps behind safety car (including SC out lap)
+laps = 2

--- a/settings.ini
+++ b/settings.ini
@@ -1,17 +1,17 @@
 [settings]
 # Minimum number of safety cars to appear during the race
-min_safety_cars = 1
+min_safety_cars = 0
 
 # Maximum number of safety cars to appear during the race
 max_safety_cars = 2
 
 # Start minute for possible safety car appearance
 # This is the earliest time a safety car can appear in the race, in minutes
-start_minute = 0.5
+start_minute = 5.0
 
 # End minute for possible safety car appearance
 # This is the latest time a safety car can appear in the race, in minutes
-end_minute = 1.5
+end_minute = 30.0
 
 # Minimum amount of time between safety car appearances
 # This is the minimum amount of time between safety car appearances, in minutes

--- a/settings.ini
+++ b/settings.ini
@@ -17,5 +17,5 @@ end_minute = 1.5
 # This is the minimum amount of time between safety car appearances, in minutes
 min_time_between = 10.0
 
-# Number of laps behind safety car (including SC out lap)
+# Number of laps behind safety car (including SC out lap, must be > 2)
 laps = 2


### PR DESCRIPTION
The pacelaps command is now triggered by lap count, allowing it to be sent within seconds of the safety car crossing the line for the first time, rather than some arbitrary minute value.