### PR TITLE
5 if leader pits pacelaps command fails

### DIFF
--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -94,11 +94,14 @@ class Generator:
                             )
                             time.sleep(0.05)
                             pyautogui.press("enter")
+                            self.master.add_message(
+                                f"Pacelaps command sent for {laps - 1} laps."
+                            )
 
                         # If it wasn't, let the user know
                         else:
                             self.master.add_message(
-                                "Pacelaps chat command not sent; value too low."
+                                "Pacelaps command not sent; value too low."
                             )
                         
                         break

--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -84,13 +84,23 @@ class Generator:
                         laps = int(
                             self.master.settings["settings"]["laps_under_sc"]
                         )
-                        self.ir.chat_command(1)
-                        time.sleep(0.05)
-                        pyautogui.write(
-                            f"!pacelaps {laps - 1}", interval=0.01
-                        )
-                        time.sleep(0.05)
-                        pyautogui.press("enter")
+                        
+                        # Only send if laps is greater than 1
+                        if laps > 1:
+                            self.ir.chat_command(1)
+                            time.sleep(0.05)
+                            pyautogui.write(
+                                f"!pacelaps {laps - 1}", interval=0.01
+                            )
+                            time.sleep(0.05)
+                            pyautogui.press("enter")
+
+                        # If it wasn't, let the user know
+                        else:
+                            self.master.add_message(
+                                "Pacelaps chat command not sent; value too low."
+                            )
+                        
                         break
 
                     # Wait 1 second before checking again

--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -88,7 +88,6 @@ class Generator:
             time.sleep(1)
 
         # All safety car events have been triggered
-        self.master.add_message("All safety car events triggered.")
         self.ir.shutdown()
 
     def run(self):

--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -67,7 +67,19 @@ class Generator:
 
                 # Wait for specified number of laps to be completed
                 while True:
-                    if max(self.ir["CarIdxLap"]) >= lap_at_yellow + 2:
+                    # Zip the CarIdxLap and CarIdxOnPitRoad arrays together
+                    laps_started = zip(
+                        self.ir["CarIdxLap"],
+                        self.ir["CarIdxOnPitRoad"]
+                    )
+
+                    # If pit road value is True, remove it, keeping only laps
+                    laps_started = [
+                        x[0] for x in laps_started if x[1] == False
+                    ]
+                    
+                    # If the max value is 2 laps greater than the lap at yellow
+                    if max(laps_started) >= lap_at_yellow + 2:
                         # Send the pacelaps chat command
                         laps = int(
                             self.master.settings["settings"]["laps_under_sc"]

--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -75,7 +75,7 @@ class Generator:
 
                     # If pit road value is True, remove it, keeping only laps
                     laps_started = [
-                        x[0] for x in laps_started if x[1] == False
+                        car[0] for car in laps_started if car[1] == False
                     ]
                     
                     # If the max value is 2 laps greater than the lap at yellow


### PR DESCRIPTION
# Description

Prior to sending the `!pacelaps` command, the program now also gathers the data on which cars are currently on pit road. Any cars on pit road are excluded before continuing on with the existing logic.

A few other small things were fixed, such as adjusting the output messages and adding a sanity check to make sure the user put in a reasonable value for total laps under SC (i.e. they didn't input -8 or something like that).

Fixes #5 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

After updating the logic, an AI race was run to ensure it worked the same as it did before more or less, this time of course excluding cars on pit road.