### PR TITLE
6 wave arounds should be automatic

### DIFF
--- a/src/core/app.py
+++ b/src/core/app.py
@@ -141,7 +141,7 @@ class App(tk.Tk):
 
         self.immediate_waveby_label = tk.Label(
             self,
-            text="Immediate Waveby"
+            text="Immediate Wave Arounds"
         )
         self.immediate_waveby_var = tk.IntVar()
         self.immediate_waveby_var.set(

--- a/src/core/app.py
+++ b/src/core/app.py
@@ -139,13 +139,39 @@ class App(tk.Tk):
             pady=(5, 0)
         )
 
+        self.immediate_waveby_label = tk.Label(
+            self,
+            text="Immediate Waveby"
+        )
+        self.immediate_waveby_var = tk.IntVar()
+        self.immediate_waveby_var.set(
+            self.settings["settings"]["immediate_waveby"]
+        )
+        self.immediate_waveby_checkbox = tk.Checkbutton(
+            self,
+            variable=self.immediate_waveby_var
+        )
+        self.immediate_waveby_label.grid(
+            row=6,
+            column=0,
+            sticky="e",
+            pady=(5, 0)
+        )
+        self.immediate_waveby_checkbox.grid(
+            row=6,
+            column=1,
+            sticky="w",
+            padx=(5, 0),
+            pady=(5, 0)
+        )
+
         # Create a save settings button
         self.save_button = tk.Button(
             self,
             text="Save Settings",
             command=self._save_settings
         )
-        self.save_button.grid(row=6, column=0, columnspan=2, pady=(20, 0))
+        self.save_button.grid(row=7, column=0, columnspan=2, pady=(20, 0))
 
         # Create a button to generate safety car events
         self.generate_button = tk.Button(
@@ -153,7 +179,7 @@ class App(tk.Tk):
             text="Generate Safety Car Events",
             command=self.generator.run
         )
-        self.generate_button.grid(row=7, column=0, columnspan=2, pady=(5, 0))
+        self.generate_button.grid(row=8, column=0, columnspan=2, pady=(5, 0))
 
         # Create a disabled text box to display the generated safety car events
         self.sc_text = scrolledtext.ScrolledText(
@@ -162,7 +188,7 @@ class App(tk.Tk):
             width=50,
             state="disabled"
         )
-        self.sc_text.grid(row=8, column=0, columnspan=2, padx=10, pady=10)
+        self.sc_text.grid(row=9, column=0, columnspan=2, padx=10, pady=10)
 
     def _save_settings(self):
         """Save the settings to the config file.
@@ -177,6 +203,7 @@ class App(tk.Tk):
         end_minute_entry = self.end_minute_entry.get()
         min_time_between_entry = self.min_time_between_entry.get()
         laps_under_sc_entry = self.laps_under_sc_entry.get()
+        immediate_waveby_entry = str(self.immediate_waveby_var.get())
 
         # Save the settings to the config file
         self.settings["settings"]["min_safety_cars"] = min_sc_entry
@@ -185,6 +212,7 @@ class App(tk.Tk):
         self.settings["settings"]["end_minute"] = end_minute_entry
         self.settings["settings"]["min_time_between"] = min_time_between_entry
         self.settings["settings"]["laps_under_sc"] = laps_under_sc_entry
+        self.settings["settings"]["immediate_waveby"] = immediate_waveby_entry
 
         with open("settings.ini", "w") as configfile:
             self.settings.write(configfile)

--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -132,45 +132,54 @@ class Generator:
                 if driver["CarClassID"] not in class_ids:
                     class_ids.append(driver["CarClassID"])
 
-        # Create an empty list of cars to wave around
-        cars_to_wave = []
-
         # Zip together the number of laps started, position on track, and class
         drivers = zip(
             self.ir["CarIdxLap"],
             self.ir["CarIdxLapDistPct"],
             self.ir["CarIdxClass"]
         )
+        drivers = tuple(drivers)
 
         # Get the highest started lap for each class
         highest_lap = {}
         for class_id in class_ids:
             # Get the highest lap and track position for the current class
-            max_lap = 0
+            max_lap = (0, 0)
             for driver in drivers:
                 if driver[2] == class_id:
-                    if driver[0] > max_lap:
+                    if driver[0] > max_lap[0]:
                         max_lap = (driver[0], driver[1])
 
             # Add the highest lap to the dictionary
             highest_lap[class_id] = max_lap
+
+        # Create an empty list of cars to wave around
+        cars_to_wave = []
 
         # For each driver, check if they're eligible for a wave around
         for i, driver in enumerate(drivers):
             # Get the class ID for the current driver
             driver_class = driver[2]
 
+            # If the class ID isn't in the class IDs list, skip the driver
+            if driver_class not in class_ids:
+                continue
+
+            driver_number = None
+
             # If driver has started 2 or fewer laps than class leader, wave them
             lap_target = highest_lap[driver_class][0] - 2
             if driver[0] <= lap_target:
                 driver_number = self._get_driver_number(i)
-                cars_to_wave.append(driver_number)
 
             # If they've started 1 fewer laps and are behind on track, wave them
             lap_target = highest_lap[driver_class][0] - 1
             track_pos_target = highest_lap[driver_class][1]
             if driver[0] == lap_target and driver[1] < track_pos_target:
                 driver_number = self._get_driver_number(i)
+
+            # If the driver number is not None, add it to the list
+            if driver_number is not None:
                 cars_to_wave.append(driver_number)
 
         # Send the wave chat command for each car

--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -185,6 +185,10 @@ class Generator:
                     f"Wave around command sent for car {car}."
                 )
                 time.sleep(0.05)
+        
+        # If no cars were waved around, let the user know
+        else:
+            self.master.add_message("No cars were eligible for a wave around.")
 
     def _start_safety_car(self):
         """Send a yellow flag to iRacing.

--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -120,6 +120,10 @@ class Generator:
         Args:
             None
         """
+        # If immediate waveby is disabled, return
+        if self.master.settings["settings"]["immediate_waveby"] == "0":
+            return
+        
         # Get all class IDs (except safety car)
         class_ids = []
         for driver in self.ir["DriverInfo"]["Drivers"]:

--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -92,7 +92,7 @@ class Generator:
                 # Only send if laps is greater than 1
                 if laps > 1:
                     self.ir.chat_command(1)
-                    time.sleep(0.05)
+                    time.sleep(0.1)
                     pyautogui.write(
                         f"!p {laps - 1}", interval=0.01
                     )
@@ -186,7 +186,7 @@ class Generator:
         if len(cars_to_wave) > 0:
             for car in cars_to_wave:
                 self.ir.chat_command(1)
-                time.sleep(0.05)
+                time.sleep(0.1)
                 pyautogui.write(f"!w {car}", interval=0.01)
                 time.sleep(0.05)
                 pyautogui.press("enter")
@@ -212,7 +212,7 @@ class Generator:
 
         # Send yellow flag chat command
         self.ir.chat_command(1)
-        time.sleep(0.05)
+        time.sleep(0.1)
         pyautogui.write("!y", interval=0.01)
         time.sleep(0.05)
         pyautogui.press("enter")

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -5,4 +5,5 @@ start_minute = 5
 end_minute = 30
 min_time_between = 10
 laps_under_sc = 2
+immediate_waveby = 1
 


### PR DESCRIPTION
# Description

A setting has been added to the GUI to turn on or off Immediate Wave Arounds. When on, all lapped cars are sent a `!waveby` command right after the safety car is thrown. This also accounts for different classes, so cars will only be waved by if they are lapped within their own class. When the setting is off, wave arounds are handled only by iRacing's built in wave around logic.

Fixes #6 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

I ran about a dozen AI races, testing various states of being lapped and seeing how the program logic responded to it. As far as I have found, the wave arounds are given at the correct times.