### PR TITLE
Gracefully exits the generator thread when the main window closes

### DIFF
--- a/src/core/app.py
+++ b/src/core/app.py
@@ -24,9 +24,23 @@ class App(tk.Tk):
 
         # Create generator object
         self.generator = generator.Generator(self)
+        self.shutdown_event = self.generator.shutdown_event
+
+        # Set handler for closing main window event
+        self.protocol('WM_DELETE_WINDOW', self.handle_delete_window)
 
         # Create widgets
         self._create_widgets()
+
+
+    def handle_delete_window(self):
+        """ Event handler to trigger shutdown_event and destroy the main window
+        
+        Args:
+            None
+        """
+        self.shutdown_event.set()
+        self.destroy()
 
     def _create_widgets(self):
         """Create widgets for the main application window.

--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -25,6 +25,16 @@ class Generator:
         self.last_sc_time = None
         self.total_random_sc_events = 0
 
+        self.shutdown_event = threading.Event()
+
+    def _is_shutting_down(self):
+        """ Returns True if shutdown_event event was triggered
+        
+        Args:
+            None
+        """
+        return self.shutdown_event.is_set()
+
     def _check_random(self):
         """Check to see if a random safety car event should be triggered.
         
@@ -214,6 +224,10 @@ class Generator:
             self._check_stopped()
             self._check_off_track()
 
+            # Break the loop if we are shutting down the thread
+            if self._is_shutting_down():
+                break
+
             # Wait 1 second before checking again
             time.sleep(1)
 
@@ -262,6 +276,10 @@ class Generator:
                 # Break the loop
                 break
 
+            # Break the loop if we are shutting down the thread
+            if self._is_shutting_down():
+                break
+            
             # Wait 1 second before checking again
             time.sleep(1)
 
@@ -408,6 +426,10 @@ class Generator:
                 )
 
                 # Break the loop
+                break
+
+            # Break the loop if we are shutting down the thread
+            if self._is_shutting_down():
                 break
 
             # Wait 1 second before checking again


### PR DESCRIPTION
# Description

When connected to iRacing the Generator thread loop starts, but the only exit conditions are the max number of safety cars deployed and the race duration. I've added another condition: checking a threading.Event object, which will be set when the main window closes. 

There was another solution: just use a daemon thread. This setting makes the thread closes as soon as the main thread closes, but with no time to release resources. So I went with the other solution.

Fixes #13

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

- Open iRacing and start a session
- Run this software from the console
- Click on the "Run" button and wait for the message "Waiting for the green flag..." appear
- Close the main window; The app will close and the console will return to the prompt;