### PR TITLE
20 sending 1 to green closes pits again so sending at the line messes up races

### DIFF
--- a/src/build.bat
+++ b/src/build.bat
@@ -4,7 +4,7 @@ ECHO Building binary. Please wait...
 :: Import pywinauto before building to avoid missing library error
 python -c "import pywinauto"
 :: Build new binary
-pyinstaller --noconfirm --log-level=FATAL --noconsole --onefile --hidden-import=comtypes.gen.UIAutomationClient main.py
+pyinstaller --noconfirm --log-level=FATAL --noconsole --onefile --hidden-import=comtypes.gen.UIAutomationClient --name=iRSCG main.py
 
 ECHO Copying files to dist...
 :: Copy settings.ini to dist

--- a/src/build.bat
+++ b/src/build.bat
@@ -2,7 +2,8 @@
 :: This batch file builds a Windows binary executable
 ECHO Building binary. Please wait...
 :: Build new binary
-pyinstaller --noconfirm --log-level=FATAL --noconsole --onefile main.py
+python -c "import pywinauto"
+pyinstaller --noconfirm --log-level=FATAL --noconsole --onefile --hidden-import=comtypes.gen.UIAutomationClient main.py
 
 ECHO Copying files to dist...
 :: Copy settings.ini to dist

--- a/src/build.bat
+++ b/src/build.bat
@@ -1,8 +1,9 @@
 @ECHO OFF
 :: This batch file builds a Windows binary executable
 ECHO Building binary. Please wait...
-:: Build new binary
+:: Import pywinauto before building to avoid missing library error
 python -c "import pywinauto"
+:: Build new binary
 pyinstaller --noconfirm --log-level=FATAL --noconsole --onefile --hidden-import=comtypes.gen.UIAutomationClient main.py
 
 ECHO Copying files to dist...

--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -296,6 +296,9 @@ class Generator:
                     if lap == max(laps_started):
                         lead_lap.append(i)
 
+                # Before next check, wait 1s to make sure leader is across line
+                time.sleep(1)
+
                 # Wait for max value in lap distance of the lead cars to be 50%
                 while True:
                     # Get the lap distance of these cars
@@ -303,12 +306,9 @@ class Generator:
                         self.ir["CarIdxLapDistPct"][car] for car in lead_lap
                     ]
 
-                    print(lead_dist)
-
                     # If any lead car is at 50%, break the loop
-                    for dist in lead_dist:
-                        if dist >= 0.5:
-                            break
+                    if any([dist >= 0.5 for dist in lead_dist]):
+                        break
 
                     # Break the loop if we are shutting down the thread
                     if self._is_shutting_down():

--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -261,14 +261,13 @@ class Generator:
         Args:
             None
         """
-        logging.info("Sending pacelaps command")
-
         # Get relevant settings from the settings file
         laps_under_sc = int(
             self.master.settings["settings"]["laps_under_sc"]
         )
 
         # If laps under safety car is 0, return
+        logging.debug("Laps under safety car set to 0; letting iRacing handle")
         if laps_under_sc == 0:
             return
 
@@ -276,6 +275,7 @@ class Generator:
         lap_at_yellow = max(self.ir["CarIdxLap"])
 
         # Wait for specified number of laps to be completed
+        logging.debug(f"Waiting for safety car to complete enough laps")
         while True:
             # Zip the CarIdxLap and CarIdxOnPitRoad arrays together
             laps_started = zip(
@@ -290,6 +290,7 @@ class Generator:
             
             # If the max value is 2 laps greater than the lap at yellow
             if max(laps_started) >= lap_at_yellow + 2:
+
                 # Get all cars on lead lap at check (in case multiple crossed)
                 lead_lap = []
                 for i, lap in enumerate(laps_started):
@@ -300,6 +301,7 @@ class Generator:
                 time.sleep(1)
 
                 # Wait for max value in lap distance of the lead cars to be 50%
+                logging.debug("Waiting for lead car to be halfway around track")
                 while True:
                     # Get the lap distance of these cars
                     lead_dist = [
@@ -319,6 +321,7 @@ class Generator:
 
                 # Only send if laps is greater than 1
                 if laps_under_sc > 1:
+                    logging.info("Sending pacelaps command")
                     self.ir_window.set_focus()
                     self.ir.chat_command(1)
                     time.sleep(0.5)

--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -268,6 +268,10 @@ class Generator:
             self.master.settings["settings"]["laps_under_sc"]
         )
 
+        # If laps under safety car is 0, return
+        if laps_under_sc == 0:
+            return
+
         # Get the max value from all cars' lap started count
         lap_at_yellow = max(self.ir["CarIdxLap"])
 
@@ -286,6 +290,33 @@ class Generator:
             
             # If the max value is 2 laps greater than the lap at yellow
             if max(laps_started) >= lap_at_yellow + 2:
+                # Get all cars on lead lap at check (in case multiple crossed)
+                lead_lap = []
+                for i, lap in enumerate(laps_started):
+                    if lap == max(laps_started):
+                        lead_lap.append(i)
+
+                # Wait for max value in lap distance of the lead cars to be 50%
+                while True:
+                    # Get the lap distance of these cars
+                    lead_dist = [
+                        self.ir["CarIdxLapDistPct"][car] for car in lead_lap
+                    ]
+
+                    print(lead_dist)
+
+                    # If any lead car is at 50%, break the loop
+                    for dist in lead_dist:
+                        if dist >= 0.5:
+                            break
+
+                    # Break the loop if we are shutting down the thread
+                    if self._is_shutting_down():
+                        break
+
+                    # Wait 1 second before checking again
+                    time.sleep(1)
+
                 # Only send if laps is greater than 1
                 if laps_under_sc > 1:
                     self.ir_window.set_focus()

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -1,13 +1,13 @@
 [settings]
 max_safety_cars = 2
-start_minute = 0.5
+start_minute = 3
 end_minute = 30
-min_time_between = 8
-laps_under_sc = 5
+min_time_between = 10
+laps_under_sc = 3
 imm_wave_around = 1
 random = 1
 random_max_occ = 1
-random_prob = 1
+random_prob = 0.1
 random_message = Hazard on track.
 stopped = 1
 stopped_min = 2

--- a/src/settings.ini
+++ b/src/settings.ini
@@ -1,13 +1,13 @@
 [settings]
 max_safety_cars = 2
-start_minute = 0
+start_minute = 0.5
 end_minute = 30
 min_time_between = 8
-laps_under_sc = 3
+laps_under_sc = 5
 imm_wave_around = 1
 random = 1
 random_max_occ = 1
-random_prob = 0.1
+random_prob = 1
 random_message = Hazard on track.
 stopped = 1
 stopped_min = 2

--- a/src/tooltips_text.json
+++ b/src/tooltips_text.json
@@ -11,6 +11,6 @@
     "start_minute": "Earliest time a safety car can be deployed after the race starts (in minutes).",
     "end_minute": "Latest time a safety car can be deployed after the race starts (in minutes).",
     "min_time_between": "Minimum time interval before another safety car can be deployed.",
-    "laps_under_sc": "Number of laps a safety car remains deployed. A value of 0 here allows iRacing to automatically control the number of laps instead.",
+    "laps_under_sc": "Number of laps a safety car remains deployed. A value of 0 here allows iRacing to automatically control the number of laps instead. The command is sent halfway around the lap to avoid closing pits while drivers are pitting.",
     "immediate_wave_around": "Sends a wave around command to all lapped cars immediately after a safety car is deployed."
 }

--- a/src/tooltips_text.json
+++ b/src/tooltips_text.json
@@ -11,6 +11,6 @@
     "start_minute": "Earliest time a safety car can be deployed after the race starts (in minutes).",
     "end_minute": "Latest time a safety car can be deployed after the race starts (in minutes).",
     "min_time_between": "Minimum time interval before another safety car can be deployed.",
-    "laps_under_sc": "Number of laps a safety car remains deployed. A value of 0 here allows iRacing to automatically control the number of laps instead. The command is sent halfway around the lap to avoid closing pits while drivers are pitting.",
+    "laps_under_sc": "Number of laps a safety car remains deployed. A value of 0 here allows iRacing to automatically control the number of laps instead. The command is sent halfway around the lap to avoid closing pits while drivers are pitting.\n\nNOTE: A value of 1 will be ignored by iRacing!",
     "immediate_wave_around": "Sends a wave around command to all lapped cars immediately after a safety car is deployed."
 }


### PR DESCRIPTION
# Description

The laps to green command is now sent halfway around the second lap behind the safety car. This avoids the scenario in which the user has set the laps behind safety car setting to 2, thus throwing 1 to green at the line and closing the pits as people are pitting. By waiting until halfway around the lap, drivers should have an opportunity to get into the pits while they're still open even if the safety car length is only 2.

Various small fixes were also made. Notably, the tooltip for the laps under safety car setting was expanded, the build file was fixed (the build was failing due to a library not being bundled) and the executable is now named correctly on build, and further logging statements were added.

Fixes #20 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Numerous AI races were run around various lengths of track to make sure the command was working as expected. The software functioned as expected in all cases.