### PR TITLE
48 env variable for logging

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+# Dev settings
+LOGGING_LEVEL=DEBUG

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 pywinauto==0.6.8
 pyinstaller
 pyirsdk==1.3.5
+python-dotenv==1.0.1

--- a/src/main.py
+++ b/src/main.py
@@ -29,7 +29,7 @@ def setup_logging():
 
     logging.config.dictConfig(logging_conf)
 
-    logging.getLogger().setLevel(level=os.getenv('LOGGING_LEVEL', logging.INFO).upper())
+    logging.getLogger().setLevel(level=os.getenv("LOGGING_LEVEL", "INFO").upper())
 
     # Log the start of the program
     logger.info("Program started")

--- a/src/main.py
+++ b/src/main.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+from dotenv import load_dotenv
+
 import logging
 import logging.config
 import json
@@ -6,6 +8,7 @@ import os
 
 from core.app import App
 
+load_dotenv()  # take environment variables from .env.
 
 def setup_logging():
     """Set up logging configuration."""
@@ -25,6 +28,8 @@ def setup_logging():
     logging_conf["handlers"]["file"]["filename"] = logfile.replace("{current_datetime}", current_datetime)
 
     logging.config.dictConfig(logging_conf)
+
+    logging.getLogger().setLevel(level=os.getenv('LOGGING_LEVEL', logging.INFO).upper())
 
     # Log the start of the program
     logger.info("Program started")


### PR DESCRIPTION
# Description

This introduces passing environment variables through a `.env` file. Now implemented for setting the `LOGGING_LEVEL` (defaults to `INFO`). Note that this introduces the python-dotenv dependency.

Fixes #48

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Test A
- Ran the application without generating the `.env` file
- Confirmed that the logs contained the messages for INFO level

Test B
- Copied `.env.sample` to `.env`, which sets the `LOGGING_LEVEL` to `DEBUG`
- Ran the application
- Confirmed the log included `DEBUG` level messages