### PR TITLE
#46 Skip wait for green

### DIFF
--- a/src/core/app.py
+++ b/src/core/app.py
@@ -19,6 +19,7 @@ class App(tk.Tk):
         """
         logger.info("Initializing main application window")
         super().__init__()
+        self.arguments = arguments
 
         # Tooltips text
         self.load_tooltips_text()
@@ -34,6 +35,7 @@ class App(tk.Tk):
         # Create generator object
         self.generator = generator.Generator(arguments, self)
         self.shutdown_event = self.generator.shutdown_event
+        self.skip_wait_for_green_event = self.generator.skip_wait_for_green_event
 
         # Set handler for closing main window event
         self.protocol('WM_DELETE_WINDOW', self.handle_delete_window)
@@ -644,6 +646,32 @@ class App(tk.Tk):
             padx=5,
             pady=5
         )
+        controls_row += 1
+
+        # Add dev mode controls
+        if self.arguments.developer_mode:
+            logger.debug("Creating developer_mode UI")
+            self.frm_dev_mode = ttk.LabelFrame(self.frm_controls, text="DEVELOPER MODE")
+            self.frm_dev_mode.grid(
+                row=controls_row,
+                column=0,
+                sticky="ew", 
+                padx=5,
+                pady=5
+            )
+
+            self.btn_skip_wait_for_green = ttk.Button(
+                self.frm_dev_mode,
+                text="Skip Wait for Green",
+                command=self._skip_wait_for_green
+            )
+            self.btn_skip_wait_for_green.grid(
+                row=0,
+                column=0,
+                sticky="ew",
+                padx=5,
+                pady=5
+            )
 
         # Fill in the widgets with the settings from the config file
         logger.debug("Filling in widgets with settings from config file")
@@ -776,3 +804,11 @@ class App(tk.Tk):
         logger.debug(f"Setting status label to: {message}")
         self.lbl_status["text"] = message
         self.update_idletasks()
+
+    def _skip_wait_for_green(self):
+        """Move from waiting for green to monitoring session state.
+
+        Args:
+            None
+        """
+        self.skip_wait_for_green_event.set()

--- a/src/core/app.py
+++ b/src/core/app.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 class App(tk.Tk):
     """Main application window for the safety car generator."""
-    def __init__(self):
+    def __init__(self, arguments):
         """Initialize the main application window.
         
         Args:
@@ -32,7 +32,7 @@ class App(tk.Tk):
         self.title("iRacing Safety Car Generator")
 
         # Create generator object
-        self.generator = generator.Generator(self)
+        self.generator = generator.Generator(arguments, self)
         self.shutdown_event = self.generator.shutdown_event
 
         # Set handler for closing main window event

--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -528,7 +528,7 @@ class Generator:
                 # Break the loop if we are shutting down the thread or skipping the wait
                 if self._is_shutting_down() or self._skip_waiting_for_green():
                     logger.debug("Skipping wait for green because of a threading event")
-                    return
+                    break
 
                 # If the current session is PRACTICE, QUALIFY, or WARMUP
                 if sessions[current_idx] in ["PRACTICE", "QUALIFY", "WARMUP"]:
@@ -569,7 +569,14 @@ class Generator:
             # Break the loop if we are shutting down the thread or skipping the wait
             if self._is_shutting_down() or self._skip_waiting_for_green():
                 logger.debug("Skipping wait for green because of a threading event")
-                return
+                if self.start_time is None:
+                    self.start_time = time.time()
+
+                # Set the UI message
+                self.master.set_message(
+                    "Connected to iRacing\nGenerating safety cars..."
+                )
+                break
 
             # Wait 1 second before checking again
             time.sleep(1)

--- a/src/core/iracing_window.py
+++ b/src/core/iracing_window.py
@@ -1,7 +1,6 @@
 import importlib
 import logging
 
-Application = None
 logger = logging.getLogger(__name__)
 
 class IRacingWindow():
@@ -9,11 +8,11 @@ class IRacingWindow():
     def __init__(self):
         logger.debug("Instantiating IRacingWindow, importing pywinauto.application")
         self.ir_window = None
-        Application = importlib.import_module('pywinauto.application')
+        self.Application = importlib.import_module('pywinauto.application').Application
 
     def connect(self):
         logger.debug("Connect to the iRacing application window and save ref for future interactions")
-        self.ir_window = Application().connect(
+        self.ir_window = self.Application().connect(
             title="iRacing.com Simulator"
         ).top_window()
 

--- a/src/core/iracing_window.py
+++ b/src/core/iracing_window.py
@@ -1,0 +1,28 @@
+import importlib
+import logging
+
+Application = None
+logger = logging.getLogger(__name__)
+
+class IRacingWindow():
+    """ Used to keep a reference to your iRacing application window to send events. """
+    def __init__(self):
+        logger.debug("Instantiating IRacingWindow, importing pywinauto.application")
+        self.ir_window = None
+        Application = importlib.import_module('pywinauto.application')
+
+    def connect(self):
+        logger.debug("Connect to the iRacing application window and save ref for future interactions")
+        self.ir_window = Application().connect(
+            title="iRacing.com Simulator"
+        ).top_window()
+
+    def focus(self):
+        logger.debug("Set focus to iRacing Application window")
+        self.ir_window.set_focus()
+
+    def send_message(self, message):
+        logger.debug(f"Sending message to iRacing window: {message}")
+        self.ir_window.type_keys(
+            message,
+            with_spaces=True)

--- a/src/core/mock_window.py
+++ b/src/core/mock_window.py
@@ -1,0 +1,17 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+class MockWindow():
+    """ We are mocking the iRacing instance when we pass arg --disable-window-interactions. """
+    def __init__(self):
+        logger.debug("Instantiating MockWindow")
+        
+    def connect(self):
+        logger.debug("Connect to the iRacing application window and save ref for future interactions")
+        
+    def focus(self):
+        logger.debug("Set focus to iRacing Application window")
+        
+    def send_message(self, message):
+        logger.debug(f"Sending message to iRacing window: {message}")

--- a/src/logging.json
+++ b/src/logging.json
@@ -37,6 +37,18 @@
 			"handlers": [
 				"file"
 			]
+		},
+		"core.iracing_window": {
+			"level": "INFO",
+			"handlers": [
+				"file"
+			]
+		},
+		"core.mock_window": {
+			"level": "DEBUG",
+			"handlers": [
+				"file"
+			]
 		}
 	}
 }

--- a/src/main.py
+++ b/src/main.py
@@ -35,6 +35,7 @@ def parse_arguments():
         prog='iRacingSafetyCarGenerator',
         description='Trigger automated safety car events in iRacing')
     parser.add_argument('-dwi', '--disable-window-interactions', action='store_true')
+    parser.add_argument('-dev', '--developer-mode', action='store_true')
     args = parser.parse_args()
     
     return args

--- a/src/main.py
+++ b/src/main.py
@@ -29,18 +29,29 @@ def setup_logging():
     # Log the start of the program
     logger.info("Program started")
 
-def main():
+def parse_arguments():
+    import argparse
+    parser = argparse.ArgumentParser(
+        prog='iRacingSafetyCarGenerator',
+        description='Trigger automated safety car events in iRacing')
+    parser.add_argument('-dwi', '--disable-window-interactions', action='store_true')
+    args = parser.parse_args()
+    
+    return args
+
+def main(arguments):
     """Main function for the safety car generator."""
     # Set up logging
     setup_logging()
 
     # Try to create and run the app, and log exceptions
     try:
-        app = App()
+        app = App(arguments)
         app.mainloop()
     except Exception as e:
         logging.exception("A fatal error has occurred")
         raise e
 
 if __name__ == "__main__":
-    main()
+    arguments = parse_arguments()
+    main(arguments)


### PR DESCRIPTION
# Description

This PR includes a number of things:
* Added argument `--disable-window-interactions` / `-dwi` to replace the interactions with the iRacing Application window with a mock implementation of said interactions. This removes a dependency on `pywinauto.application`, which is Windows only (and thus allows me to do some dev on MacOS..)
* Added argument `--developer-mode` / `-dev`, which will show a `DEVELOPER MODE` section in the UI
* Added a button `Skip Wait for Green` in the dev-mode tools that will send a signal to the Generator thread to bypass the loop that is waiting for the green flags

Fixes #46 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Testing

* Start a race session
* Wait for it to go green
* Start the application with the `-dev` param - this will show a developers section in the UI
* Now start the SCG - as expected, it will remain in the "waiting for green" state
* Press "Skip wait for green", it will now start monitoring for incidents
* Crash out some silly cars and confirm it is throwing yellows