### PR TITLE
Adding non-system-specific launch settings for VSCode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # VSCode
-.vscode/
+.vscode/*
+!.vscode/launch.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: iRacingSafetycarGenerator",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "main.py",
+            "console": "integratedTerminal",
+            "args": ["-dev"],
+            "cwd": "${workspaceFolder}/src"
+        },
+        {
+            "name": "Python Debugger: iRacingSafetycarGenerator (MacOS)",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "main.py",
+            "console": "integratedTerminal",
+            "args": ["-dev", "-dwi"],
+            "cwd": "${workspaceFolder}/src"
+        }
+    ]
+}


### PR DESCRIPTION
# Description

Opening this one up to debate if this should be part of the repo. There are opinions online to exclude it and there are opinions to include it. I think adding these non-system-specific launch configs can help people to contribute faster.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Nice to have for development contributors

# Testing

* Open the project in VS code
* Find two debugger launch options to use the app in dev mode