### PR TITLE
Proximity check across S/F and sliding window approach

### DIFF
--- a/src/core/tests/test_generator.py
+++ b/src/core/tests/test_generator.py
@@ -167,6 +167,35 @@ def test_adjust_for_proximity_equidistant_cars(generator):
         num += 1
         
     result = generator._adjust_for_proximity(car_indexes_list)
-    # This should return 3 because each car (except the ends of the list) is within range of
-    # the car before and after it in the list
-    assert result == 3
+    # This should return 2 because the sliding window of length 0.05 will only ever contain two cars
+    assert result == 2
+
+def test_adjust_for_proximity_longer_distance_across_finish(generator):
+    generator.master.settings["settings"]["proximity_yellows"] = 1
+    generator.master.settings["settings"]["proximity_yellows_distance"] = 0.40
+    car_indexes_list = [2, 4, 6, 8, 10, 12]
+    car_distances_list = [0.7, 0.8, 0.9, 1.0, 0.1, 0.2]
+    num = 0
+    for idx in car_indexes_list:
+        generator.drivers.current_drivers[idx]["lap_distance"] = car_distances_list[num]
+        num += 1
+        
+    result = generator._adjust_for_proximity(car_indexes_list)
+    # This should return 5 because only the cars on the ends are not in range
+    assert result == 5
+
+def test_adjust_for_proximity_lapped_cars(generator):
+    """ This situation should not happen but adding in case we mess up in the future """
+    generator.master.settings["settings"]["proximity_yellows"] = 1
+    generator.master.settings["settings"]["proximity_yellows_distance"] = 0.40
+    car_indexes_list = [2, 4, 6, 8, 10, 12]
+    car_distances_list = [1.7, 2.8, 3.9, 4.0, 5.1, 6.2]
+    num = 0
+    for idx in car_indexes_list:
+        generator.drivers.current_drivers[idx]["lap_distance"] = car_distances_list[num]
+        num += 1
+        
+    result = generator._adjust_for_proximity(car_indexes_list)
+    # This should return 5 because only the cars on the ends are not in range
+    # This is an extreme example with cars on different laps, but still at the same spot
+    assert result == 5


### PR DESCRIPTION
# Description

This PR fixes #86 and slightly changes the logic for what we consider "in proximity".
* Current logic would consider cars in a cluster if there is any one car that has the other cars within the specified range (while the other cars not necessarily are within the specified range). The adjustments make it so that cars are only in proximity if they are all within the specified distance from each other.
* The logic now also works across the S/F line. This is accomplished by sorting all the car distances and then adding them all again one lap ahead (i.e. if we have cars at positions `[0.1, 0.2, 0.8, 0.9]`, we'd now check clusters for elements `[0.1, 0.2, 0.8, 0.9, 1.1, 1.2, 1.8, 1.9]`).
* Added an extra check to make sure all values passed in are in the range 0.0-1.0.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

`pytest`