### PR TITLE
Update build-release.yml

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,7 +27,8 @@ on:
 jobs:
   build:
     runs-on: windows-latest
-
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Setting write permissions on contents to be able to create the release/tag.

Refer to https://github.com/joshjaysalazar/iRacingSafetyCarGenerator/actions/runs/15892463744/job/44817466112#step:8:49

`GitHub release failed with status: 403`