### PR TITLE
72 commands not sending

### DIFF
--- a/src/core/app.py
+++ b/src/core/app.py
@@ -8,7 +8,7 @@ from core import generator
 from core import tooltip
 from core.generator import GeneratorState
 from util.state_utils import generator_state_messages, is_stopped_state
-from util.dev_utils import copy_sdk_data_to_clipboard
+from util.dev_utils import copy_sdk_data_to_clipboard, send_test_commands
 
 logger = logging.getLogger(__name__)
 
@@ -867,6 +867,19 @@ class App(tk.Tk):
                 pady=5
             )
 
+            self.btn_send_test_commands = ttk.Button(
+                self.frm_dev_mode,
+                text="Send test commands",
+                command=self._send_test_commands
+            )
+            self.btn_send_test_commands.grid(
+                row=2,
+                column=0,
+                sticky="ew",
+                padx=5,
+                pady=5
+            )
+
         # Fill in the widgets with the settings from the config file
         logger.debug("Filling in widgets with settings from config file")
         self.var_random.set(self.settings["settings"].getboolean("random"))
@@ -1058,3 +1071,12 @@ class App(tk.Tk):
             None
         """
         copy_sdk_data_to_clipboard()
+
+    def _send_test_commands(self):
+        """Send test commands to iRacing to understand rate limiting.
+
+        Args:
+            None
+        """
+        send_test_commands()
+        

--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -1,32 +1,18 @@
-from collections import deque
 import logging
 import math
 import random
 import threading
 import time
-import traceback
 
 import irsdk
 
 from core import drivers
-from core.interactions import command_sender
-from core.interactions import iracing_window
-from core.interactions import mock_window
-from core.interactions import mock_sender
+from core.interactions.interaction_factories import CommandSenderFactory
 
+from collections import deque
 from enum import Enum
 
 logger = logging.getLogger(__name__)
-
-def WindowFactory(arguments):
-    if arguments and arguments.disable_window_interactions:
-        return mock_window.MockWindow()
-    return iracing_window.IRacingWindow()
-
-def CommandSenderFactory(arguments, iracing_window, ir):
-    if arguments and arguments.dry_run:
-        return mock_sender.MockSender()
-    return command_sender.CommandSender(iracing_window, ir)
 
 class GeneratorState(Enum):
     STOPPED = 1
@@ -55,8 +41,7 @@ class Generator:
         # Create the iRacing SDK object and command sender
         logger.debug("Initializing SDK and CommandSender")
         self.ir = irsdk.IRSDK()
-        iracing_window = WindowFactory(arguments)
-        self.command_sender = CommandSenderFactory(arguments, iracing_window, self.ir)
+        self.command_sender = CommandSenderFactory(arguments, self.ir)
 
         # Variables to track safety car events
         logger.debug("Initializing safety car variables")

--- a/src/core/interactions/command_sender.py
+++ b/src/core/interactions/command_sender.py
@@ -33,10 +33,11 @@ class CommandSender:
 
         self.iracing_window.focus()
         self.irsdk.chat_command(1)
-        if delay > 0:
-            logger.debug(f"Adding delay between chat command and send_message of: {delay}")
-            time.sleep(delay)
         self.iracing_window.send_message(f"{command}{{ENTER}}")
+        
+        if delay > 0:
+            logger.debug(f"Adding delay after sending chat message: {delay}")
+            time.sleep(delay)
 
     def send_commands(self, commands, delay = 0.5):
         """ Sends the list of commands in order with the provided delay.

--- a/src/core/interactions/interaction_factories.py
+++ b/src/core/interactions/interaction_factories.py
@@ -1,0 +1,33 @@
+from core.interactions import command_sender
+from core.interactions import iracing_window
+from core.interactions import mock_window
+from core.interactions import mock_sender
+
+def WindowFactory(arguments):
+    """ Create an IRacingWindow instance, possibly a mock one, based on the provided arguments.
+
+    Args:
+        arguments: Launch arguments indicating if we want to disable window interactions.
+
+    Returns:
+        IRacingWindow: An instance of IRacingWindow or MockWindow based on the arguments.
+    """
+    if arguments and arguments.disable_window_interactions:
+        return mock_window.MockWindow()
+    return iracing_window.IRacingWindow()
+
+def CommandSenderFactory(arguments, ir):
+    """ Create a CommandSender instance, possibly a mock one, based on the provided arguments.
+
+    Args:
+        arguments: Launch arguments indicating if we want to use a mock sender or not.
+        ir (irSDK): An instance of irSDK to used for interacting with iRacing.
+
+    Returns:
+        CommandSender: An instance of CommandSender or MockSender based on the arguments.
+    """
+    if arguments and arguments.dry_run:
+        return mock_sender.MockSender()
+    
+    iracing_window = WindowFactory(arguments)
+    return command_sender.CommandSender(iracing_window, ir)

--- a/src/core/tests/test_generator.py
+++ b/src/core/tests/test_generator.py
@@ -1,8 +1,11 @@
 import pytest
 import time
 import math
+
 from unittest.mock import Mock
 from core.generator import Generator
+from core.interactions.command_sender import CommandSender
+from core.interactions.mock_sender import MockSender
 
 @pytest.fixture
 def generator():
@@ -25,6 +28,23 @@ def generator():
         mock_drivers.current_drivers.append({"lap_distance": 0})
     setattr(gen, "drivers", mock_drivers)
     return gen
+
+def test_command_sender_init():
+    """Test the initialization of the CommandSender."""
+    mock_arguments = Mock()    
+    # This needs to be True to make tests work on MacOS
+    mock_arguments.disable_window_interactions = True
+    
+    # We need the generator to send actual commands
+    mock_arguments.dry_run = False
+    generator = Generator(arguments=mock_arguments)
+    assert isinstance(generator.command_sender, CommandSender)
+
+    # In this case, we want to avoid sending commands
+    mock_arguments.dry_run = True
+    generator = Generator(arguments=mock_arguments)
+    assert isinstance(generator.command_sender, MockSender)
+
 
 def test_threshold_no_multiplier(generator):
     """Test when multiplier is 0."""

--- a/src/util/dev_utils.py
+++ b/src/util/dev_utils.py
@@ -2,6 +2,8 @@ import irsdk
 import json
 import pyperclip
 
+from core.interactions.interaction_factories import CommandSenderFactory
+
 def copy_sdk_data_to_clipboard():
     """Takes a snapshot of data provided by the SDK and copies it to your clipboard
     
@@ -30,6 +32,28 @@ def copy_sdk_data_to_clipboard():
         }
         
         pyperclip.copy(json.dumps(data, indent=4))
+
+    finally:
+        if connected:
+            ir.shutdown()
+
+def send_test_commands():
+    ir = irsdk.IRSDK()
+    connected = False
+    try:
+        if not ir.startup():
+            print("Could not connect through the SDK")
+            return
+        connected = True
+
+        arguments = lambda: None
+        arguments.dry_run = False
+        arguments.disable_window_interactions = False
+
+        command_sender = CommandSenderFactory(arguments, ir) # type: ignore
+        for i in range(1, 60):
+            command_sender.send_command(f"Test Command {i}", 1.0)
+            print(f"Sent command: Test Command {i}")
 
     finally:
         if connected:

--- a/src/util/dev_utils.py
+++ b/src/util/dev_utils.py
@@ -38,6 +38,17 @@ def copy_sdk_data_to_clipboard():
             ir.shutdown()
 
 def send_test_commands():
+    """This util was written to test the limits of iRacing receiving chat commands. We 
+    noticed if delays between messages were too short, iRacing would drop some of the 
+    messages, which is detrimental to a lot of our procedures.
+    Testing showed that with a delay of 0.1 seconds, we would see a drop after every 
+    16th message. This was resolved with a 0.2 second delay, so we are using 0.5 seconds 
+    in our application to be safe.
+    
+    Other notes:
+        - Performance was worse when sitting in the car than when just in the garage view.
+        - We moved the delay until after the chat command was sent, which seemed to help.
+    """
     ir = irsdk.IRSDK()
     connected = False
     try:
@@ -51,9 +62,20 @@ def send_test_commands():
         arguments.disable_window_interactions = False
 
         command_sender = CommandSenderFactory(arguments, ir) # type: ignore
-        for i in range(1, 60):
-            command_sender.send_command(f"Test Command {i}", 1.0)
-            print(f"Sent command: Test Command {i}")
+        command_sender.connect()
+        
+        # Uncomment for sending regular chat commands
+        # for i in range(1, 100):
+        #     command_sender.send_command(f"Test Command {i}", 0.5)
+        #     print(f"Sent command: Test Command {i}")
+        
+        cars_to_wave = []
+        for driver in ir["DriverInfo"]["Drivers"]:
+            cars_to_wave.append(driver["CarNumber"])
+            
+        for car in cars_to_wave:
+            command_sender.send_command(f"!w {car}")
+            print(f"!w {car}")
 
     finally:
         if connected:


### PR DESCRIPTION
# Description

While implementing class splits and wave arounds, wave commands would sometimes be ignored by iRacing, which is a huge issue impacting the running order in a race. I added a dev tool to send wave arounds for the whole field to be able to test when messages get dropped.

I found that when delays between regular chat messages is 0.1s, after every 16 messages there is a period in which messages are being ignored. This was very consistent. By increasing the delay to 0.2s, this was resolved, so I kept it at 0.5s to be safe.

Secondly, when I switched to actually sending wave commands, it would fumble harder. This seemed to be worse when driving around vs. just sending commands from the garage. Playing around with different delays and the order of our interact operations I found that by removing the delay between the sdk chat command and sending the keystrokes, this resolved messages from being fumbled. I tested this several times with a 40 car grid, so I have a level of confidence this should be good now.

Fixes #72. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

See description. Also added some tests for the minor refactor I did on interactions initialization.