### PR TITLE
Fix a bug where proximity checks were never disabled

### DIFF
--- a/src/core/generator.py
+++ b/src/core/generator.py
@@ -245,7 +245,7 @@ class Generator:
         Returns:
             The number of cars stopped/off-track which are within N percent of a lap_distance of each other
         """
-        proximity_yellows_enabled = bool(self.master.settings["settings"]["proximity_yellows"])
+        proximity_yellows_enabled = self.master.settings["settings"]["proximity_yellows"] == "1"
         proximity_yellows_distance = float(self.master.settings["settings"]["proximity_yellows_distance"])
         
         # If we are not using proximity-based yellows, return the length of the original list

--- a/src/core/tests/test_generator.py
+++ b/src/core/tests/test_generator.py
@@ -87,7 +87,7 @@ def test_threshold_no_adjustment_due_to_time(generator):
 
 def test_adjust_for_proximity_disabled(generator):
     """Test adjustment method when proximity_yellows = 0"""
-    generator.master.settings["settings"]["proximity_yellows"] = 0
+    generator.master.settings["settings"]["proximity_yellows"] = "0"
     car_indexes_list = [2, 4, 6, 8, 10]
     car_distances_list = [0.1, 0.2, 0.3, 0.4, 0.5]
     num = 0
@@ -100,7 +100,7 @@ def test_adjust_for_proximity_disabled(generator):
 
 def test_adjust_for_proximity_empty_list_arg(generator):
     """Test adjustment method when the passed list is empty"""
-    generator.master.settings["settings"]["proximity_yellows"] = 1
+    generator.master.settings["settings"]["proximity_yellows"] = "1"
     car_indexes_list = []
 
     result = generator._adjust_for_proximity(car_indexes_list)
@@ -108,7 +108,7 @@ def test_adjust_for_proximity_empty_list_arg(generator):
 
 def test_adjust_for_proximity_no_cars_in_range(generator):
     """Test adjustment method when no cars are within range of each other"""
-    generator.master.settings["settings"]["proximity_yellows"] = 1
+    generator.master.settings["settings"]["proximity_yellows"] = "1"
     car_indexes_list = [2, 4, 6, 8, 10]
     car_distances_list = [0.1, 0.2, 0.3, 0.4, 0.5]
     num = 0
@@ -121,7 +121,7 @@ def test_adjust_for_proximity_no_cars_in_range(generator):
 
 def test_adjust_for_proximity_single_outlier(generator):
     """Test adjustment method when a single outlier exists"""
-    generator.master.settings["settings"]["proximity_yellows"] = 1
+    generator.master.settings["settings"]["proximity_yellows"] = "1"
     car_indexes_list = [2, 4, 6, 8]
     car_distances_list = [0.1, 0.11, 0.12, 0.2]
     num = 0
@@ -134,8 +134,8 @@ def test_adjust_for_proximity_single_outlier(generator):
 
 def test_adjust_for_proximity_distance_adjustment_down(generator):
     """Test adjustment method when the proximity distance is lowered"""
-    generator.master.settings["settings"]["proximity_yellows"] = 1
-    generator.master.settings["settings"]["proximity_yellows_distance"] = 0.01
+    generator.master.settings["settings"]["proximity_yellows"] = "1"
+    generator.master.settings["settings"]["proximity_yellows_distance"] = "0.01"
     car_indexes_list = [2, 4, 6, 8]
     car_distances_list = [0.1, 0.11, 0.14, 0.2]
     num = 0
@@ -148,8 +148,8 @@ def test_adjust_for_proximity_distance_adjustment_down(generator):
 
 def test_adjust_for_proximity_distance_adjustment_up(generator):
     """Test adjustment method when the proximity distance is raised"""
-    generator.master.settings["settings"]["proximity_yellows"] = 1
-    generator.master.settings["settings"]["proximity_yellows_distance"] = 0.10
+    generator.master.settings["settings"]["proximity_yellows"] = "1"
+    generator.master.settings["settings"]["proximity_yellows_distance"] = "0.10"
     car_indexes_list = [2, 4, 6, 8, 10]
     car_distances_list = [0.1, 0.11, 0.14, 0.2, 0.5]
     num = 0
@@ -162,7 +162,7 @@ def test_adjust_for_proximity_distance_adjustment_up(generator):
 
 def test_adjust_for_proximity_multiple_outliers(generator):
     """Test adjustment method when multiple outliers exist"""
-    generator.master.settings["settings"]["proximity_yellows"] = 1
+    generator.master.settings["settings"]["proximity_yellows"] = "1"
     car_indexes_list = [2, 4, 6, 8, 10]
     car_distances_list = [0.1, 0.11, 0.12, 0.2, 0.8]
     num = 0
@@ -175,7 +175,7 @@ def test_adjust_for_proximity_multiple_outliers(generator):
 
 def test_adjust_for_proximity_multiple_clusters(generator):
     """Test adjustment method when multiple clusters exist"""
-    generator.master.settings["settings"]["proximity_yellows"] = 1
+    generator.master.settings["settings"]["proximity_yellows"] = "1"
     car_indexes_list = [2, 4, 6, 8, 10]
     car_distances_list = [0.1, 0.11, 0.12, 0.2, 0.22]
     num = 0
@@ -188,7 +188,7 @@ def test_adjust_for_proximity_multiple_clusters(generator):
 
 def test_adjust_for_proximity_equidistant_cars(generator):
     """Test adjustment method when cars are equidistant at the threshold"""
-    generator.master.settings["settings"]["proximity_yellows"] = 1
+    generator.master.settings["settings"]["proximity_yellows"] = "1"
     car_indexes_list = [2, 4, 6, 8, 10, 12, 14]
     car_distances_list = [0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4]
     num = 0
@@ -202,8 +202,8 @@ def test_adjust_for_proximity_equidistant_cars(generator):
     assert result == 2
 
 def test_adjust_for_proximity_longer_distance_across_finish(generator):
-    generator.master.settings["settings"]["proximity_yellows"] = 1
-    generator.master.settings["settings"]["proximity_yellows_distance"] = 0.40
+    generator.master.settings["settings"]["proximity_yellows"] = "1"
+    generator.master.settings["settings"]["proximity_yellows_distance"] = "0.40"
     car_indexes_list = [2, 4, 6, 8, 10, 12]
     car_distances_list = [0.7, 0.8, 0.9, 1.0, 0.1, 0.2]
     num = 0
@@ -217,8 +217,8 @@ def test_adjust_for_proximity_longer_distance_across_finish(generator):
 
 def test_adjust_for_proximity_lapped_cars(generator):
     """ This situation should not happen but adding in case we mess up in the future """
-    generator.master.settings["settings"]["proximity_yellows"] = 1
-    generator.master.settings["settings"]["proximity_yellows_distance"] = 0.40
+    generator.master.settings["settings"]["proximity_yellows"] = "1"
+    generator.master.settings["settings"]["proximity_yellows_distance"] = "0.40"
     car_indexes_list = [2, 4, 6, 8, 10, 12]
     car_distances_list = [1.7, 2.8, 3.9, 4.0, 5.1, 6.2]
     num = 0


### PR DESCRIPTION
# Description

As I was refactoring our detection approach, I found out we are casting from a string to bool when checking if the proximity checks need to be enabled. Turns out `bool("0") == True` in python.

I updated all mocks of our settings object to contain strings, but we should make sure we use a typed object at some point.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Made sure this is covered in `pytest`.

Through the debugger confirmed what values are used when saving the settings:

<img width="606" height="520" alt="image" src="https://github.com/user-attachments/assets/5eae809e-ee4f-4d78-9afd-1d1a786c74dc" />
