### PR TITLE
Skip the pace car in the stopped checker

### DIFF
--- a/src/core/detection/stopped_detector.py
+++ b/src/core/detection/stopped_detector.py
@@ -35,6 +35,9 @@ class StoppedDetector:
         total_drivers = len(self.drivers.current_drivers)
         
         for current, previous in zip(self.drivers.current_drivers, self.drivers.previous_drivers):
+            if current["is_pace_car"]:
+                continue
+                
             if current["track_loc"] in [TrkLoc.aproaching_pits, 
                                         TrkLoc.in_pit_stall, 
                                         TrkLoc.not_in_world]:

--- a/src/core/detection/tests/test_stopped_detector.py
+++ b/src/core/detection/tests/test_stopped_detector.py
@@ -21,6 +21,21 @@ def test_detect_stopped_driver():
     assert result.has_drivers()
     assert result.drivers == [current[0]]
 
+def test_detect_skips_pace_car():
+    current = [
+        make_driver(TrkLoc.on_track, 0, 0, 1, True),
+        make_driver(TrkLoc.on_track, 5, 0.5)
+    ]
+    previous = [
+        make_driver(TrkLoc.on_track, 0, 0, 1, True),
+        make_driver(TrkLoc.on_track, 5, 0.4)
+    ]
+    drivers = MockDrivers(current, previous)
+    detector = StoppedDetector(drivers)
+    result = detector.detect()
+    assert result.has_drivers()
+    assert result.drivers == []
+
 def test_detect_skips_pit_and_not_in_world():
     current = [
         make_driver(TrkLoc.aproaching_pits, 5, 0.0),

--- a/src/core/tests/test_utils.py
+++ b/src/core/tests/test_utils.py
@@ -52,12 +52,13 @@ class MockDrivers:
         self.previous_drivers.append(make_driver(TrkLoc.not_in_world))
 
 
-def make_driver(track_loc, laps_completed = 0, lap_distance = 0.0, driver_idx = 0):
+def make_driver(track_loc, laps_completed = 0, lap_distance = 0.0, driver_idx = 0, is_pace_car = False):
     return {
         "driver_idx": driver_idx,
         "track_loc": track_loc,
         "laps_completed": laps_completed,
-        "lap_distance": lap_distance
+        "lap_distance": lap_distance,
+        "is_pace_car": is_pace_car
     }
 
 


### PR DESCRIPTION
# Description

Added check and test that skips counting the pace car in the stopped checker

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- Test A: Pytest
- Test B: AI race
  - With stopped cars minimum = 1 and earliest possible minute = 0, start the generator and the race normally. Ensure that a safety car isn't thrown immediately. Stop your car and verify that a safety car is thrown.
  - With stopped cars minimum = 2, earliest possible minute = 0, combined threshold = 3, off track weight = 2, stopped weight = 4, start the generator and the race normally. Ensure that a safety car isn't thrown immediately. Stop your car and verify that a safety car is thrown.