### PR TITLE
Detect race in progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
+# AI agents
+.claude
+
 # SDK dumps
-dumps/
+/src/dumps/
+/dumps/
 
 # VSCode
 .vscode/

--- a/src/core/tests/test_generator.py
+++ b/src/core/tests/test_generator.py
@@ -1,9 +1,10 @@
 import pytest
+import irsdk
 
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 from core.detection.threshold_checker import ThresholdChecker
 from core.detection.detector import Detector, DetectorSettings
-from core.generator import Generator
+from core.generator import Generator, GeneratorState
 from core.interactions.command_sender import CommandSender
 from core.interactions.mock_sender import MockSender
 from core.tests.test_utils import create_mock_drivers
@@ -140,3 +141,206 @@ def test_send_wave_arounds_no_eligible_cars(generator, mocker):
     result = generator._send_wave_arounds()
     mock_command_sender.assert_called_once_with([])
     assert result is True
+
+
+class TestWaitForGreenFlag:
+    """Tests for _wait_for_green_flag() method."""
+
+    @pytest.fixture
+    def generator_for_green_flag(self):
+        """Create a generator configured for green flag tests."""
+        mock_arguments = Mock()
+        mock_arguments.disable_window_interactions = True
+        mock_master = Mock()
+        mock_master.generator_state = GeneratorState.CONNECTED
+
+        mock_settings = Mock()
+        mock_master.settings = mock_settings
+
+        gen = Generator(arguments=mock_arguments, master=mock_master)
+        gen.start_time = None
+
+        # Mock the iRacing SDK
+        gen.ir = MagicMock()
+        gen.ir.__getitem__ = MagicMock()
+
+        # Mock detector and threshold_checker for _notify_race_started
+        gen.detector = Mock()
+        gen.threshold_checker = Mock()
+
+        return gen
+
+    def test_green_flag_detected(self, generator_for_green_flag):
+        """Test that green flag detection works (existing behavior)."""
+        gen = generator_for_green_flag
+
+        # Setup: Race session, green flag is set
+        gen.ir.__getitem__.side_effect = lambda key: {
+            "SessionInfo": {"Sessions": [{"SessionName": "RACE"}]},
+            "SessionNum": 0,
+            "SessionFlags": irsdk.Flags.green,
+            "SessionState": irsdk.SessionState.racing,
+        }.get(key)
+
+        gen._wait_for_green_flag(require_race_session=True)
+
+        assert gen.start_time is not None
+        assert gen.master.generator_state == GeneratorState.MONITORING_FOR_INCIDENTS
+
+    def test_race_already_in_progress_with_require_race_session_true(self, generator_for_green_flag):
+        """Test that SessionState==racing is detected when require_race_session=True."""
+        gen = generator_for_green_flag
+
+        # Setup: Race session, NO green flag, but SessionState is racing
+        gen.ir.__getitem__.side_effect = lambda key: {
+            "SessionInfo": {"Sessions": [{"SessionName": "RACE"}]},
+            "SessionNum": 0,
+            "SessionFlags": 0,  # No flags set (green flag already cleared)
+            "SessionState": irsdk.SessionState.racing,
+        }.get(key)
+
+        gen._wait_for_green_flag(require_race_session=True)
+
+        assert gen.start_time is not None
+        assert gen.master.generator_state == GeneratorState.MONITORING_FOR_INCIDENTS
+
+    def test_race_already_in_progress_ignored_with_require_race_session_false(self, generator_for_green_flag):
+        """Test that SessionState==racing is ignored when require_race_session=False (SC restart)."""
+        gen = generator_for_green_flag
+        call_count = 0
+
+        def mock_getitem(key):
+            nonlocal call_count
+            call_count += 1
+            # First few calls return no green flag, then return green flag
+            # This simulates waiting for actual green flag during SC restart
+            if key == "SessionFlags":
+                if call_count <= 3:
+                    return 0  # No flags
+                else:
+                    return irsdk.Flags.green  # Green flag on 4th+ call
+            return {
+                "SessionInfo": {"Sessions": [{"SessionName": "RACE"}]},
+                "SessionNum": 0,
+                "SessionState": irsdk.SessionState.racing,
+            }.get(key)
+
+        gen.ir.__getitem__.side_effect = mock_getitem
+
+        gen._wait_for_green_flag(require_race_session=False)
+
+        # Should have waited for actual green flag, not just SessionState
+        assert call_count >= 4
+        assert gen.start_time is not None
+        assert gen.master.generator_state == GeneratorState.MONITORING_FOR_INCIDENTS
+
+    def test_waits_for_race_session_before_checking_green(self, generator_for_green_flag):
+        """Test that it waits for race session before checking green flag."""
+        gen = generator_for_green_flag
+        session_checks = []
+
+        def mock_getitem(key):
+            if key == "SessionNum":
+                session_checks.append(len(session_checks))
+                # Return practice for first call, then race
+                if len(session_checks) <= 1:
+                    return 0  # Practice session
+                return 1  # Race session
+            if key == "SessionInfo":
+                return {"Sessions": [
+                    {"SessionName": "PRACTICE"},
+                    {"SessionName": "RACE"}
+                ]}
+            if key == "SessionFlags":
+                return irsdk.Flags.green
+            if key == "SessionState":
+                return irsdk.SessionState.racing
+            return None
+
+        gen.ir.__getitem__.side_effect = mock_getitem
+
+        gen._wait_for_green_flag(require_race_session=True)
+
+        # Should have checked session at least twice (once for practice, once for race)
+        assert len(session_checks) >= 2
+        assert gen.master.generator_state == GeneratorState.MONITORING_FOR_INCIDENTS
+
+    def test_shutdown_event_exits_early(self, generator_for_green_flag):
+        """Test that shutdown event causes early exit."""
+        gen = generator_for_green_flag
+
+        # Setup: Race session, no green flag, not racing
+        gen.ir.__getitem__.side_effect = lambda key: {
+            "SessionInfo": {"Sessions": [{"SessionName": "RACE"}]},
+            "SessionNum": 0,
+            "SessionFlags": 0,
+            "SessionState": irsdk.SessionState.parade_laps,
+        }.get(key)
+
+        # Set shutdown event
+        gen.shutdown_event.set()
+
+        gen._wait_for_green_flag(require_race_session=True)
+
+        # Should have exited and set start_time
+        assert gen.start_time is not None
+        assert gen.master.generator_state == GeneratorState.MONITORING_FOR_INCIDENTS
+
+    def test_skip_wait_event_exits_early(self, generator_for_green_flag):
+        """Test that skip_wait_for_green_event causes early exit."""
+        gen = generator_for_green_flag
+
+        # Setup: Race session, no green flag, not racing
+        gen.ir.__getitem__.side_effect = lambda key: {
+            "SessionInfo": {"Sessions": [{"SessionName": "RACE"}]},
+            "SessionNum": 0,
+            "SessionFlags": 0,
+            "SessionState": irsdk.SessionState.parade_laps,
+        }.get(key)
+
+        # Set skip event
+        gen.skip_wait_for_green_event.set()
+
+        gen._wait_for_green_flag(require_race_session=True)
+
+        # Should have exited and set start_time
+        assert gen.start_time is not None
+        assert gen.master.generator_state == GeneratorState.MONITORING_FOR_INCIDENTS
+
+    def test_green_flag_preferred_over_session_state(self, generator_for_green_flag, caplog):
+        """Test that green flag is logged when both conditions are true."""
+        gen = generator_for_green_flag
+
+        # Setup: Both green flag AND racing state
+        gen.ir.__getitem__.side_effect = lambda key: {
+            "SessionInfo": {"Sessions": [{"SessionName": "RACE"}]},
+            "SessionNum": 0,
+            "SessionFlags": irsdk.Flags.green,
+            "SessionState": irsdk.SessionState.racing,
+        }.get(key)
+
+        import logging
+        with caplog.at_level(logging.INFO):
+            gen._wait_for_green_flag(require_race_session=True)
+
+        # Green flag message should appear (checked first)
+        assert "Green flag detected" in caplog.text
+        assert "Race already in progress" not in caplog.text
+
+    def test_race_in_progress_logging(self, generator_for_green_flag, caplog):
+        """Test that race already in progress is logged correctly."""
+        gen = generator_for_green_flag
+
+        # Setup: No green flag, but racing state
+        gen.ir.__getitem__.side_effect = lambda key: {
+            "SessionInfo": {"Sessions": [{"SessionName": "RACE"}]},
+            "SessionNum": 0,
+            "SessionFlags": 0,
+            "SessionState": irsdk.SessionState.racing,
+        }.get(key)
+
+        import logging
+        with caplog.at_level(logging.INFO):
+            gen._wait_for_green_flag(require_race_session=True)
+
+        assert "Race already in progress" in caplog.text


### PR DESCRIPTION
# Description

## Problem
The generator can only be used if started before the race begins. It waits for the green flag (`SessionFlags & Flags.green`), but this flag is only set for ~22 seconds after green waves, then clears. If started after this window, the generator never transitions to monitoring.

## Solution
Use `SessionState == irsdk.SessionState.racing` as an additional condition to detect that a race is already in progress, but **only at initial race start context** (not during SC restart).

## Verification Summary
Analyzed three SDK dump files:
- `local_session_start_race_plus_two_laps.ndjson` - race start as driver
- `local_session_start_race_then_full_sc_cycle.ndjson` - race start + full SC cycle
- `local_session_start_race_plus_two_laps_as_spectator.ndjson` - race start as spectator

**Key findings:**
1. `SessionState == 4 (racing)` is set when race starts and stays set throughout
2. Green flag is only set for ~22 seconds after waving
3. During SC period, `SessionState` remains `racing` - caution flags indicate SC
4. The `require_race_session` parameter already distinguishes race start vs SC restart contexts
5. Behavior is identical for drivers and spectators

## Why This Works

| Scenario | `require_race_session` | SessionState | Result |
|----------|------------------------|--------------|--------|
| Start before race | `True` | parade_laps → racing | Waits for green, transitions correctly |
| Start mid-race | `True` | already racing | Immediately proceeds (race detected) |
| SC restart wait | `False` | racing | Only waits for green flag (correct) |
| Start mid-race during SC | `True` | racing | Proceeds, but will see caution and handle appropriately |


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

`pytest`
* In a local session, started generator before race start - waited correctly
* Forced a safety car - waited correctly for green
* Restarted the SCG mid-race - went immediately to scanning for incidents

## Checklist

- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Documentation Updates

Please check the boxes below if your changes affect these documentation files:

- [ ] Updated [.ai-context.md](../.ai-context.md) if adding new patterns or conventions
- [ ] Updated [ARCHITECTURE.md](../ARCHITECTURE.md) if changing system design or workflows
- [ ] Updated [.ai-modules.md](../.ai-modules.md) if adding new modules or changing module responsibilities
- [ ] Updated [README.md](../README.md) if changing user-facing features or setup instructions
- [ ] Updated [docs/RACING_CONCEPTS.md](../docs/RACING_CONCEPTS.md) if adding new racing concepts or terminology
- [x] No documentation updates needed