### PR TITLE
Skip waves for non-racing drivers

### DIFF
--- a/src/core/procedures/wave_arounds.py
+++ b/src/core/procedures/wave_arounds.py
@@ -2,6 +2,8 @@ import logging
 from enum import Enum
 from typing import List
 
+from irsdk import TrkLoc
+
 from core.drivers import Driver
 from util.generator_utils import positions_from_safety_car
 
@@ -120,7 +122,7 @@ def _get_lapped_car_indices(drivers: List[Driver], pace_car_idx: int) -> List[in
     # For each driver, check if they're eligible for a wave around
     for driver in drivers:
         # Skip pace car
-        if driver["driver_idx"] == pace_car_idx or driver["on_pit_road"]:
+        if driver["driver_idx"] == pace_car_idx or driver["on_pit_road"] or driver["track_loc"] in [TrkLoc.not_in_world, TrkLoc.in_pit_stall, TrkLoc.aproaching_pits]:
             continue
 
         # Get the class ID for the current driver
@@ -214,8 +216,8 @@ def _get_ahead_of_class_lead_indices(drivers: List[Driver], pace_car_idx: int) -
     # Identify cars ahead of their class leader and behind the overall lead
     for driver in drivers:
         idx = driver["driver_idx"]
-        if idx == pace_car_idx or driver["on_pit_road"]:
-            logger.debug(f"Skipping driver idx {idx} (pace car or on pit road)")
+        if idx == pace_car_idx or driver["on_pit_road"] or driver["track_loc"] in [TrkLoc.not_in_world, TrkLoc.in_pit_stall, TrkLoc.aproaching_pits]:
+            logger.debug(f"Skipping driver idx {idx} (pace car, on pit road, or ineligible track location)")
             continue
 
         car_class = driver["car_class_id"]


### PR DESCRIPTION
# Description

Now more explicitly skip waves for cars not in world, approaching pits or in pit stall.

Fixes #16 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

`pytest`

## Checklist

- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Documentation Updates

Please check the boxes below if your changes affect these documentation files:

- [ ] Updated [.ai-context.md](../.ai-context.md) if adding new patterns or conventions
- [ ] Updated [ARCHITECTURE.md](../ARCHITECTURE.md) if changing system design or workflows
- [ ] Updated [.ai-modules.md](../.ai-modules.md) if adding new modules or changing module responsibilities
- [ ] Updated [README.md](../README.md) if changing user-facing features or setup instructions
- [ ] Updated [docs/RACING_CONCEPTS.md](../docs/RACING_CONCEPTS.md) if adding new racing concepts or terminology
- [x] No documentation updates needed