### PR TITLE
Adds E2E testing framework and regression tests

### DIFF
--- a/.ai-context.md
+++ b/.ai-context.md
@@ -28,6 +28,7 @@ class GeneratorState(Enum):
 ```
 
 **State Transitions:**
+
 - `STOPPED` → `CONNECTING_TO_IRACING` (user clicks start)
 - `CONNECTING_TO_IRACING` → `CONNECTED` (SDK connection established)
 - `CONNECTED` → `WAITING_FOR_RACE_SESSION` (connection verified)
@@ -36,6 +37,7 @@ class GeneratorState(Enum):
 - `MONITORING_FOR_INCIDENTS` ↔ `SAFETY_CAR_DEPLOYED` (threshold met / green flag)
 
 **Property-Based Access (src/core/app.py:161-165):**
+
 ```python
 @property
 def generator_state(self) -> GeneratorState:
@@ -86,6 +88,7 @@ class SupportsDetect(Protocol):
 ```
 
 **When to add new detector:**
+
 1. Implement the `SupportsDetect` protocol
 2. Add event type to `DetectorEventTypes` enum
 3. Update `Detector.build_detector()` to instantiate your detector
@@ -155,6 +158,7 @@ self.skip_wait_for_green_event = threading.Event()
 ```
 
 **Thread Safety:**
+
 - Main thread: Tkinter GUI (App)
 - Generator thread: Detection loop and procedures
 - No shared mutable state between threads
@@ -174,11 +178,13 @@ self.skip_wait_for_green_event = threading.Event()
 ### Type Hints
 
 **Always use type hints for:**
+
 - Function parameters and return values
 - Class attributes (especially in TypedDict)
 - Variables when type isn't obvious from assignment
 
 **TypedDict for data models:**
+
 ```python
 # src/core/drivers.py:5-14
 class Driver(TypedDict):
@@ -195,6 +201,7 @@ class Driver(TypedDict):
 ```
 
 **Dataclasses for configuration:**
+
 ```python
 # src/core/detection/detector_common_types.py:53-60
 @dataclass(frozen=True)
@@ -210,12 +217,14 @@ class DetectorSettings:
 ### Logging
 
 **Per-module loggers:**
+
 ```python
 import logging
 logger = logging.getLogger(__name__)
 ```
 
 **Log levels:**
+
 - `logger.debug()`: Detailed diagnostic information
 - `logger.info()`: General informational messages (state changes, events)
 - `logger.warning()`: Unexpected behavior that doesn't stop execution
@@ -343,13 +352,27 @@ Check both `on_pit_road` and `track_loc` for comprehensive pit detection:
 
 ```python
 # src/core/detection/stopped_detector.py:51-53
-if driver["track_loc"] in [TrkLoc.approaching_pits, TrkLoc.in_pit_stall] or driver["track_loc"] == TrkLoc.not_in_world:
+if driver["track_loc"] in [TrkLoc.aproaching_pits, TrkLoc.in_pit_stall] or driver["track_loc"] == TrkLoc.not_in_world:
     continue
 ```
+
+**5. TrkLoc is not a standard Python Enum:**
+`irsdk.TrkLoc` looks like an enum but is a custom class — it is **not iterable** (`for t in TrkLoc` raises `TypeError`). Its values are plain integers:
+
+| Constant                 | Value |
+| ------------------------ | ----- |
+| `TrkLoc.not_in_world`    | `-1`  |
+| `TrkLoc.off_track`       | `0`   |
+| `TrkLoc.in_pit_stall`    | `1`   |
+| `TrkLoc.aproaching_pits` | `2`   |
+| `TrkLoc.on_track`        | `3`   |
+
+Note the **typo** `aproaching_pits` (one 'p') — this is the actual irsdk constant name. In NDJSON dumps, `CarIdxTrackSurface` stores these as raw integers, so comparisons work with either the constant or the int value. When writing tests against dump data, compare with the `TrkLoc` constants.
 
 ### Threading Model
 
 **Generator runs in separate thread:**
+
 - Main loop runs at ~1 Hz (1 second sleep + loop execution time)
 - Uses `threading.Event` for coordination (shutdown, manual SC, skip wait)
 - Never directly modify GUI from Generator thread
@@ -358,6 +381,7 @@ if driver["track_loc"] in [TrkLoc.approaching_pits, TrkLoc.in_pit_stall] or driv
 ### Windows Automation Timing
 
 **Command delays are critical:**
+
 ```python
 # src/core/interactions/command_sender.py:33-34
 time.sleep(0.1)  # Wait for iRacing UI to update
@@ -366,6 +390,7 @@ time.sleep(0.5)  # Delay between commands to avoid rate limiting
 ```
 
 **Focus requirement:**
+
 - pywinauto requires the iRacing window to have focus
 - Users cannot alt-tab during safety car procedures
 - Use `-dwi` flag for development without Windows automation
@@ -373,6 +398,7 @@ time.sleep(0.5)  # Delay between commands to avoid rate limiting
 ### State Management
 
 **Always use property setters:**
+
 ```python
 # Good - triggers GUI update
 self.generator_state = GeneratorState.MONITORING_FOR_INCIDENTS
@@ -411,6 +437,7 @@ def clean_up_events(self, current_time: float):
 ```
 
 **Key features:**
+
 - Events expire after `time_range` seconds (default: 5s)
 - Per-driver tracking prevents double-counting
 - Supports both per-event-type and accumulative (weighted) thresholds
@@ -474,6 +501,7 @@ def detect(self) -> BundledDetectedEvents:
 ## Quick Command Reference
 
 ### Running Tests
+
 ```bash
 pytest                    # Run all tests
 pytest -v                 # Verbose output
@@ -482,11 +510,13 @@ pytest --cov              # With coverage report
 ```
 
 ### Building Application
+
 ```bash
 python build.py           # Build executable with PyInstaller
 ```
 
 ### Development Flags
+
 ```bash
 python src/main.py -dev   # Enable developer panel
 python src/main.py -dwi   # Don't use Windows interactions (cross-platform dev)

--- a/src/core/tests/e2e_utils.py
+++ b/src/core/tests/e2e_utils.py
@@ -1,0 +1,381 @@
+"""End-to-end test utilities for replaying NDJSON SDK dumps through the detection pipeline.
+
+This module provides a replay harness that feeds recorded SDK frames through the same
+Detector/ThresholdChecker components used by the Generator, enabling deterministic testing
+of safety car triggering and wave around logic against real session data.
+
+Usage:
+    from core.tests.e2e_utils import DumpReplayer, make_settings
+
+    replayer = DumpReplayer(
+        dump_path=Path("docs/dumps/my_recording.ndjson"),
+        settings=make_settings(stopped_cars_threshold=3),
+    )
+    result = replayer.run()
+    assert result.total_safety_cars() >= 1
+"""
+
+import json
+import logging
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+from unittest.mock import patch
+
+import irsdk
+
+from core.detection.detector import Detector, DetectorSettings
+from core.detection.detector_common_types import DetectionResult, DetectorEventTypes
+from core.detection.threshold_checker import ThresholdChecker, ThresholdCheckerSettings
+from core.drivers import Driver
+from core.procedures.wave_arounds import wave_around_type_from_selection, wave_arounds_factory
+from core.settings import Settings
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Result data classes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DetectionLogEntry:
+    """Per-frame detection snapshot for debugging."""
+    frame_index: int
+    timestamp: float
+    stopped_drivers: list[int] = field(default_factory=list)
+    off_track_drivers: list[int] = field(default_factory=list)
+    random_triggered: bool = False
+    threshold_met: bool = False
+
+
+@dataclass
+class SafetyCarEvent:
+    """Records when and why a safety car was triggered."""
+    frame_index: int
+    timestamp: float
+    reason: str = ""
+    wave_commands: list[str] = field(default_factory=list)
+    wave_frame_index: Optional[int] = None
+
+
+@dataclass
+class ReplayResult:
+    """Aggregated results from a dump replay run."""
+    safety_car_events: list[SafetyCarEvent] = field(default_factory=list)
+    detection_log: list[DetectionLogEntry] = field(default_factory=list)
+    frame_count: int = 0
+
+    def total_safety_cars(self) -> int:
+        return len(self.safety_car_events)
+
+    def sc_triggered_at_frame(self, frame_index: int) -> bool:
+        return any(sc.frame_index == frame_index for sc in self.safety_car_events)
+
+    def wave_commands_for_sc(self, sc_index: int) -> list[str]:
+        """Get wave around commands for the Nth safety car event (0-indexed)."""
+        if sc_index < len(self.safety_car_events):
+            return self.safety_car_events[sc_index].wave_commands
+        return []
+
+    def waved_car_numbers_for_sc(self, sc_index: int) -> list[str]:
+        """Get car numbers waved for the Nth safety car event (0-indexed)."""
+        commands = self.wave_commands_for_sc(sc_index)
+        return [cmd.replace("!w ", "") for cmd in commands]
+
+
+# ---------------------------------------------------------------------------
+# Mock Drivers for replay
+# ---------------------------------------------------------------------------
+
+class ReplayDrivers:
+    """Lightweight Drivers replacement that updates from dump frames instead of the SDK.
+
+    Maintains the same interface as core.drivers.Drivers so that detectors work unchanged:
+    - current_drivers / previous_drivers (double-buffer)
+    - session_info with pace_car_idx
+    """
+
+    def __init__(self):
+        self.current_drivers: list[Driver] = []
+        self.previous_drivers: list[Driver] = []
+        self.session_info: dict = {"pace_car_idx": -1}
+
+    def update_from_frame(self, frame: dict) -> None:
+        """Update driver state from a single NDJSON dump frame.
+
+        Mirrors the logic of Drivers.update() but reads from the dump frame
+        instead of the live SDK.
+        """
+        self.previous_drivers = deepcopy(self.current_drivers)
+        self.current_drivers = []
+
+        telemetry = frame["telemetry"]
+        driver_info = frame["session_info"]["DriverInfo"]["Drivers"]
+
+        laps_completed = telemetry["CarIdxLapCompleted"]
+        laps_started = telemetry["CarIdxLap"]
+        lap_distance = telemetry["CarIdxLapDistPct"]
+        track_loc = telemetry["CarIdxTrackSurface"]
+        on_pit_road = telemetry["CarIdxOnPitRoad"]
+
+        self.session_info = {
+            "pace_car_idx": frame["session_info"]["DriverInfo"]["PaceCarIdx"],
+        }
+
+        for driver_details in driver_info:
+            car_idx = driver_details["CarIdx"]
+            self.current_drivers.append({
+                "driver_idx": car_idx,
+                "car_number": driver_details["CarNumber"],
+                "car_class_id": driver_details["CarClassID"],
+                "car_class_est_lap_time": driver_details["CarClassEstLapTime"],
+                "is_pace_car": driver_details["CarIsPaceCar"] == 1,
+                "laps_completed": laps_completed[car_idx],
+                "laps_started": laps_started[car_idx],
+                "lap_distance": lap_distance[car_idx],
+                "total_distance": laps_completed[car_idx] + lap_distance[car_idx],
+                "track_loc": track_loc[car_idx],
+                "on_pit_road": on_pit_road[car_idx],
+            })
+
+
+# ---------------------------------------------------------------------------
+# Settings helper
+# ---------------------------------------------------------------------------
+
+def make_settings(**overrides) -> Settings:
+    """Create a Settings object for testing, with sensible defaults and per-setting overrides.
+
+    All settings start with their Settings class fallback defaults. Any keyword argument
+    matching a Settings property name will override that value.
+
+    Example:
+        settings = make_settings(
+            stopped_cars_threshold=3,
+            off_track_cars_threshold=5,
+            wave_arounds_enabled=True,
+            laps_before_wave_arounds=1,
+            wave_around_rules_index=0,
+            detection_start_minute=0.0,
+            detection_end_minute=60.0,
+        )
+    """
+    # Create a Settings backed by an in-memory ConfigParser (no file I/O).
+    # Settings.__init__ reads from a file, but a non-existent path just yields an empty config.
+    settings = Settings(config_file="/dev/null")
+
+    # Apply overrides via property setters (which write to the underlying ConfigParser)
+    for key, value in overrides.items():
+        if not hasattr(settings, key):
+            raise ValueError(f"Unknown setting: {key}")
+        setattr(settings, key, value)
+
+    return settings
+
+
+# ---------------------------------------------------------------------------
+# Dump Replayer
+# ---------------------------------------------------------------------------
+
+class DumpReplayer:
+    """Replays an NDJSON SDK dump through the detection pipeline frame-by-frame.
+
+    This replays the same detection logic that Generator._loop() uses:
+    1. Update drivers from the frame
+    2. Run all enabled detectors
+    3. Register results with the ThresholdChecker
+    4. Check if threshold is met → record safety car event
+    5. Optionally compute wave around commands for each SC
+
+    Args:
+        dump_path: Path to the NDJSON dump file.
+        settings: A Settings object (use make_settings() to create one).
+            If None, default settings are used.
+        compute_waves: Whether to compute wave around commands at each SC event.
+            Wave arounds are computed at the frame where the SC fires, using
+            the current driver state. For more realistic wave timing, see
+            compute_waves_after_laps.
+        compute_waves_after_laps: If set, wave around commands are computed
+            this many laps after the SC lap (matching laps_before_wave_arounds).
+            Requires the dump to have enough frames after the SC.
+
+    Usage:
+        replayer = DumpReplayer(
+            Path("docs/dumps/race_weird_sc_with_lots_of_waves.ndjson"),
+            settings=make_settings(stopped_cars_threshold=2),
+        )
+        result = replayer.run()
+        print(f"SCs triggered: {result.total_safety_cars()}")
+        for i, sc in enumerate(result.safety_car_events):
+            print(f"  SC {i}: frame {sc.frame_index}, waves: {sc.wave_commands}")
+    """
+
+    def __init__(
+        self,
+        dump_path: Path,
+        settings: Optional[Settings] = None,
+        compute_waves: bool = True,
+        compute_waves_after_laps: Optional[int] = None,
+    ):
+        self.dump_path = Path(dump_path)
+        self.settings = settings or make_settings()
+        self.compute_waves = compute_waves
+        self.compute_waves_after_laps = compute_waves_after_laps
+
+    def _load_frames(self) -> list[dict]:
+        """Load all frames from the NDJSON dump file."""
+        frames = []
+        with open(self.dump_path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    frames.append(json.loads(line))
+        return frames
+
+    @staticmethod
+    def _detect_race_active(frame: dict) -> bool:
+        """Check if the race is active in this frame.
+
+        Looks for green flag OR SessionState == racing (4), matching the
+        Generator's logic which considers both conditions.
+        """
+        flags = frame["telemetry"].get("SessionFlags", 0)
+        state = frame["telemetry"].get("SessionState", 0)
+        green_flag = flags & irsdk.Flags.green
+        racing = state == irsdk.SessionState.racing
+        return bool(green_flag or racing)
+
+    def _get_wave_commands(self, drivers: ReplayDrivers) -> list[str]:
+        """Compute wave around commands using current driver state."""
+        wave_around_type = wave_around_type_from_selection(
+            self.settings.wave_around_rules_index
+        )
+        wave_func = wave_arounds_factory(wave_around_type)
+        return wave_func(
+            drivers.current_drivers,
+            drivers.session_info["pace_car_idx"],
+        )
+
+    def _get_current_lap_from_frame(self, frame: dict) -> int:
+        """Get the current max lap from frame telemetry (excluding pit road cars)."""
+        laps = frame["telemetry"]["CarIdxLap"]
+        on_pit = frame["telemetry"]["CarIdxOnPitRoad"]
+        active_laps = [lap for lap, pit in zip(laps, on_pit) if not pit and lap >= 0]
+        return max(active_laps) if active_laps else 0
+
+    def run(self) -> ReplayResult:
+        """Replay the dump and return results.
+
+        Processes each frame through the detection pipeline, tracking when
+        safety cars would trigger and what wave arounds would be sent.
+        """
+        frames = self._load_frames()
+        result = ReplayResult(frame_count=len(frames))
+
+        # Build components from settings (same as Generator.run)
+        drivers = ReplayDrivers()
+        detector_settings = DetectorSettings.from_settings(self.settings)
+        detector = Detector.build_detector(detector_settings, drivers)
+        tc_settings = ThresholdCheckerSettings.from_settings(self.settings)
+        threshold_checker = ThresholdChecker(tc_settings)
+
+        race_started = False
+        start_time = None
+
+        # Track pending wave arounds (SC events waiting for the right lap)
+        pending_waves: list[tuple[SafetyCarEvent, int]] = []  # (sc_event, wave_target_lap)
+
+        for i, frame in enumerate(frames):
+            frame_time = frame["_metadata"]["epoch"]
+
+            # Patch time.time so ThresholdChecker/Detector use frame timestamps
+            with patch("time.time", return_value=frame_time):
+                # Update drivers from frame
+                drivers.update_from_frame(frame)
+
+                # Detect race start
+                if not race_started and self._detect_race_active(frame):
+                    race_started = True
+                    start_time = frame_time
+                    detector.race_started(start_time)
+                    threshold_checker.race_started(start_time)
+                    logger.debug(f"Race detected as active at frame {i}")
+                    continue
+
+                if not race_started:
+                    continue
+
+                # Check eligibility window
+                elapsed_minutes = (frame_time - start_time) / 60.0
+                if elapsed_minutes < self.settings.detection_start_minute:
+                    continue
+                if elapsed_minutes > self.settings.detection_end_minute:
+                    break
+
+                # Run detection cycle
+                detector_results = detector.detect()
+                threshold_checker.clean_up_events()
+
+                # Build detection log entry
+                log_entry = DetectionLogEntry(
+                    frame_index=i,
+                    timestamp=frame_time,
+                )
+
+                for event_type in DetectorEventTypes:
+                    detection_result = detector_results.get_events(event_type)
+                    if detection_result:
+                        threshold_checker.register_detection_result(detection_result)
+                        # Log what was detected
+                        if detection_result.has_drivers():
+                            driver_idxs = [d["driver_idx"] for d in detection_result.drivers]
+                            if event_type == DetectorEventTypes.STOPPED:
+                                log_entry.stopped_drivers = driver_idxs
+                            elif event_type == DetectorEventTypes.OFF_TRACK:
+                                log_entry.off_track_drivers = driver_idxs
+                        elif detection_result.has_detected_flag() and detection_result.detected_flag:
+                            log_entry.random_triggered = True
+
+                # Check threshold
+                if threshold_checker.threshold_met():
+                    log_entry.threshold_met = True
+
+                    sc_event = SafetyCarEvent(
+                        frame_index=i,
+                        timestamp=frame_time,
+                        reason="Threshold met",
+                    )
+
+                    if self.compute_waves:
+                        if self.compute_waves_after_laps is not None:
+                            # Defer wave computation to a later frame
+                            lap_at_sc = self._get_current_lap_from_frame(frame)
+                            wave_target = lap_at_sc + self.compute_waves_after_laps + 1
+                            pending_waves.append((sc_event, wave_target))
+                        else:
+                            # Compute waves immediately at the SC frame
+                            sc_event.wave_commands = self._get_wave_commands(drivers)
+
+                    result.safety_car_events.append(sc_event)
+
+                    # Reset threshold checker for next potential SC
+                    threshold_checker = ThresholdChecker(tc_settings)
+                    threshold_checker.race_started(start_time)
+
+                result.detection_log.append(log_entry)
+
+                # Process pending wave arounds (check if we've reached the target lap)
+                if pending_waves:
+                    current_lap = self._get_current_lap_from_frame(frame)
+                    still_pending = []
+                    for sc_event, wave_target in pending_waves:
+                        if current_lap >= wave_target:
+                            sc_event.wave_commands = self._get_wave_commands(drivers)
+                            sc_event.wave_frame_index = i
+                        else:
+                            still_pending.append((sc_event, wave_target))
+                    pending_waves = still_pending
+
+        return result

--- a/src/core/tests/test_e2e_detection_and_procedures.py
+++ b/src/core/tests/test_e2e_detection_and_procedures.py
@@ -1,0 +1,584 @@
+"""End-to-end tests using NDJSON dump replay.
+
+These tests replay real SDK recordings through the detection pipeline to validate
+safety car triggering, wave around logic, and threshold behavior. They serve as
+both regression tests and a template for writing new scenario tests.
+
+GETTING STARTED — How to write a new e2e test:
+
+1. Pick a dump file from docs/dumps/ (or record a new one in dev mode).
+
+2. Create settings with make_settings(), overriding only what you need:
+       settings = make_settings(
+           stopped_cars_threshold=2,       # How many stopped cars trigger SC
+           off_track_cars_threshold=3,      # How many off-track cars trigger SC
+           stopped_detector_enabled=True,   # Enable/disable stopped detector
+           off_track_detector_enabled=True, # Enable/disable off-track detector
+           random_detector_enabled=False,   # Random SC (usually off for deterministic tests)
+           proximity_filter_enabled=False,  # Proximity-based clustering
+           proximity_filter_distance_percentage=0.05,
+           event_time_window_seconds=5.0,   # Sliding window for threshold checking
+           race_start_threshold_multiplier=1.0,  # 1.0 = no multiplier
+           race_start_threshold_multiplier_time_seconds=0.0,
+           detection_start_minute=0.0,      # Earliest SC possible (minutes)
+           detection_end_minute=60.0,       # Latest SC possible (minutes)
+           max_safety_cars=10,              # Max SCs per race
+           wave_arounds_enabled=True,       # Whether to send wave arounds
+           laps_before_wave_arounds=1,      # Laps after SC before waving
+           wave_around_rules_index=0,       # 0=lapped, 1=ahead of lead, 2=combined
+       )
+
+3. Create a DumpReplayer and run:
+       replayer = DumpReplayer(dump_path, settings=settings)
+       result = replayer.run()
+
+4. Assert on the result:
+       result.total_safety_cars()           → int: number of SCs triggered
+       result.safety_car_events[n]          → SafetyCarEvent with frame_index, wave_commands
+       result.waved_car_numbers_for_sc(n)   → list[str]: car numbers waved at SC n
+       result.sc_triggered_at_frame(idx)    → bool: was SC triggered at this frame?
+       result.detection_log                 → list[DetectionLogEntry]: per-frame details
+
+   DetectionLogEntry has:
+       .frame_index, .timestamp
+       .stopped_drivers   → list[int] of driver_idx values detected as stopped
+       .off_track_drivers → list[int] of driver_idx values detected as off-track
+       .threshold_met     → bool: was threshold met at this frame?
+
+For wave around testing with realistic lap timing:
+       replayer = DumpReplayer(
+           dump_path,
+           settings=settings,
+           compute_waves_after_laps=1,  # Compute waves 1 lap after SC
+       )
+"""
+
+from pathlib import Path
+
+from core.tests.e2e_utils import DumpReplayer, make_settings
+
+DUMPS_DIR = Path(__file__).resolve().parents[3] / "docs" / "dumps"
+
+
+# ---------------------------------------------------------------------------
+# Test: Safety car triggering with different thresholds
+# ---------------------------------------------------------------------------
+
+class TestSafetyCarTriggering:
+    """Tests that validate whether a SC fires under various threshold settings.
+
+    The dump 'race_weird_sc_with_lots_of_waves.ndjson' contains:
+    - Car #153 off-track at frames 0-7
+    - Cars #108 and #88 off-track at frames 13-24
+    - Cars #108 and #88 stopped at frames 17-19
+    """
+
+    dump = DUMPS_DIR / "race_weird_sc_with_lots_of_waves.ndjson"
+
+    def test_sc_triggers_with_low_off_track_threshold(self):
+        """With off-track threshold=2 and the two-car incident around frame 13,
+        a safety car should be triggered."""
+        replayer = DumpReplayer(self.dump, settings=make_settings(
+            off_track_detector_enabled=True,
+            off_track_cars_threshold=2,
+            stopped_detector_enabled=False,
+            random_detector_enabled=False,
+            proximity_filter_enabled=False,
+            race_start_threshold_multiplier=1.0,
+            event_time_window_seconds=5.0,
+            detection_start_minute=0.0,
+            detection_end_minute=60.0,
+            max_safety_cars=10,
+        ))
+        result = replayer.run()
+
+        assert result.total_safety_cars() >= 1, (
+            f"Expected at least 1 SC with off_track_threshold=2, got {result.total_safety_cars()}"
+        )
+
+    def test_sc_triggers_with_low_stopped_threshold(self):
+        """With stopped threshold=2, the stopped cars at frames 17-19 should trigger a SC."""
+        replayer = DumpReplayer(self.dump, settings=make_settings(
+            stopped_detector_enabled=True,
+            stopped_cars_threshold=2,
+            off_track_detector_enabled=False,
+            random_detector_enabled=False,
+            proximity_filter_enabled=False,
+            race_start_threshold_multiplier=1.0,
+            event_time_window_seconds=5.0,
+            detection_start_minute=0.0,
+            detection_end_minute=60.0,
+            max_safety_cars=10,
+        ))
+        result = replayer.run()
+
+        assert result.total_safety_cars() >= 1, (
+            f"Expected at least 1 SC with stopped_threshold=2, got {result.total_safety_cars()}"
+        )
+
+    def test_no_sc_with_high_thresholds(self):
+        """With very high thresholds, no SC should be triggered."""
+        replayer = DumpReplayer(self.dump, settings=make_settings(
+            stopped_detector_enabled=True,
+            stopped_cars_threshold=50,
+            off_track_detector_enabled=True,
+            off_track_cars_threshold=50,
+            random_detector_enabled=False,
+            proximity_filter_enabled=False,
+            race_start_threshold_multiplier=1.0,
+            detection_start_minute=0.0,
+            detection_end_minute=60.0,
+            max_safety_cars=10,
+        ))
+        result = replayer.run()
+
+        assert result.total_safety_cars() == 0, (
+            f"Expected 0 SCs with high thresholds, got {result.total_safety_cars()}"
+        )
+
+    def test_single_off_track_car_does_not_trigger(self):
+        """Car #153 alone off-track (frames 0-7) should NOT trigger SC at threshold=2."""
+        replayer = DumpReplayer(self.dump, settings=make_settings(
+            off_track_detector_enabled=True,
+            off_track_cars_threshold=2,
+            stopped_detector_enabled=False,
+            random_detector_enabled=False,
+            proximity_filter_enabled=False,
+            race_start_threshold_multiplier=1.0,
+            event_time_window_seconds=5.0,
+            detection_start_minute=0.0,
+            detection_end_minute=60.0,
+            max_safety_cars=10,
+        ))
+        result = replayer.run()
+
+        # The first SC should not fire before frame 13 (when 2 cars go off-track)
+        if result.total_safety_cars() > 0:
+            first_sc_frame = result.safety_car_events[0].frame_index
+            assert first_sc_frame >= 13, (
+                f"SC triggered too early at frame {first_sc_frame}, expected >= 13"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test: Race start multiplier
+# ---------------------------------------------------------------------------
+
+class TestRaceStartMultiplier:
+    """Tests that validate the dynamic threshold multiplier at race start."""
+
+    dump = DUMPS_DIR / "race_weird_sc_with_lots_of_waves.ndjson"
+
+    def test_high_multiplier_prevents_sc(self):
+        """A high race start multiplier should prevent SC during the multiplier window."""
+        replayer = DumpReplayer(self.dump, settings=make_settings(
+            off_track_detector_enabled=True,
+            off_track_cars_threshold=2,
+            stopped_detector_enabled=False,
+            random_detector_enabled=False,
+            proximity_filter_enabled=False,
+            race_start_threshold_multiplier=10.0,  # 10x multiplier
+            race_start_threshold_multiplier_time_seconds=120.0,  # Active for 2 minutes
+            event_time_window_seconds=5.0,
+            detection_start_minute=0.0,
+            detection_end_minute=60.0,
+            max_safety_cars=10,
+        ))
+        result = replayer.run()
+
+        # The dump is only 60s long, and with a 10x multiplier active for 120s,
+        # a threshold of 2 becomes effectively 20 — should not trigger
+        assert result.total_safety_cars() == 0, (
+            f"Expected 0 SCs with 10x race start multiplier, got {result.total_safety_cars()}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: Wave around commands
+# ---------------------------------------------------------------------------
+
+class TestWaveArounds:
+    """Tests that validate which cars get waved around and in what order.
+
+    The dump at the end (frame 59) shows:
+    - Cars #257, #951, #924 are 2+ laps behind (should always be waved)
+    - Many cars are 1 lap behind
+    """
+
+    dump = DUMPS_DIR / "race_weird_sc_with_lots_of_waves.ndjson"
+
+    def test_wave_lapped_cars_includes_multi_lap_down(self):
+        """Cars 2+ laps down should be waved using the 'wave lapped cars' rule."""
+        replayer = DumpReplayer(self.dump, settings=make_settings(
+            off_track_detector_enabled=True,
+            off_track_cars_threshold=2,
+            stopped_detector_enabled=False,
+            random_detector_enabled=False,
+            proximity_filter_enabled=False,
+            race_start_threshold_multiplier=1.0,
+            event_time_window_seconds=5.0,
+            detection_start_minute=0.0,
+            detection_end_minute=60.0,
+            max_safety_cars=10,
+            wave_arounds_enabled=True,
+            wave_around_rules_index=0,  # Wave lapped cars
+            laps_before_wave_arounds=0,
+        ))
+        result = replayer.run()
+
+        if result.total_safety_cars() > 0:
+            waved = result.waved_car_numbers_for_sc(0)
+            # Cars 2+ laps down at time of SC should be waved
+            # Note: which cars are waved depends on the frame state when the SC fires
+            # This is a structural test — verify we get some wave commands
+            print(f"Wave commands at SC: {result.wave_commands_for_sc(0)}")
+            print(f"Waved cars: {waved}")
+
+    def test_no_wave_arounds_when_disabled(self):
+        """When wave arounds are disabled, no wave commands should be produced."""
+        replayer = DumpReplayer(self.dump, settings=make_settings(
+            off_track_detector_enabled=True,
+            off_track_cars_threshold=2,
+            stopped_detector_enabled=False,
+            random_detector_enabled=False,
+            proximity_filter_enabled=False,
+            race_start_threshold_multiplier=1.0,
+            event_time_window_seconds=5.0,
+            detection_start_minute=0.0,
+            detection_end_minute=60.0,
+            max_safety_cars=10,
+            wave_arounds_enabled=True,
+            wave_around_rules_index=0,
+        ), compute_waves=False)
+        result = replayer.run()
+
+        if result.total_safety_cars() > 0:
+            assert result.wave_commands_for_sc(0) == [], (
+                f"Expected no wave commands when compute_waves=False"
+            )
+
+    def test_wave_around_rules_comparison(self):
+        """Compare different wave around rules on the same scenario.
+
+        This test demonstrates how to compare the three wave strategies.
+        """
+        base_settings = dict(
+            off_track_detector_enabled=True,
+            off_track_cars_threshold=2,
+            stopped_detector_enabled=False,
+            random_detector_enabled=False,
+            proximity_filter_enabled=False,
+            race_start_threshold_multiplier=1.0,
+            event_time_window_seconds=5.0,
+            detection_start_minute=0.0,
+            detection_end_minute=60.0,
+            max_safety_cars=10,
+            wave_arounds_enabled=True,
+            laps_before_wave_arounds=0,
+        )
+
+        results = {}
+        for rule_name, rule_index in [
+            ("wave_lapped_cars", 0),
+            ("wave_ahead_of_class_lead", 1),
+            ("wave_combined", 2),
+        ]:
+            replayer = DumpReplayer(self.dump, settings=make_settings(
+                **base_settings,
+                wave_around_rules_index=rule_index,
+            ))
+            result = replayer.run()
+            if result.total_safety_cars() > 0:
+                results[rule_name] = result.waved_car_numbers_for_sc(0)
+            else:
+                results[rule_name] = []
+
+        # Log all results for manual inspection / future pinning
+        for rule_name, waved in results.items():
+            print(f"{rule_name}: {len(waved)} cars waved: {waved}")
+
+        # Combined should include at least as many cars as either individual rule
+        if results["wave_lapped_cars"] and results["wave_combined"]:
+            lapped_set = set(results["wave_lapped_cars"])
+            combined_set = set(results["wave_combined"])
+            assert lapped_set.issubset(combined_set), (
+                f"Combined rule should include all lapped cars. "
+                f"Missing: {lapped_set - combined_set}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test: Proximity filter effect
+# ---------------------------------------------------------------------------
+
+class TestProximityFilter:
+    """Tests that validate the proximity-based yellow flag clustering.
+
+    When proximity filtering is enabled, only incidents where cars are close
+    together on track should count toward the threshold.
+    """
+
+    dump = DUMPS_DIR / "race_weird_sc_with_lots_of_waves.ndjson"
+
+    def test_proximity_filter_may_change_outcome(self):
+        """Compare SC triggering with and without proximity filter.
+
+        This test documents the effect of the proximity filter on the scenario.
+        Depending on where the off-track cars are relative to each other,
+        the proximity filter may prevent or allow the SC.
+        """
+        base = dict(
+            off_track_detector_enabled=True,
+            off_track_cars_threshold=2,
+            stopped_detector_enabled=False,
+            random_detector_enabled=False,
+            race_start_threshold_multiplier=1.0,
+            event_time_window_seconds=5.0,
+            detection_start_minute=0.0,
+            detection_end_minute=60.0,
+            max_safety_cars=10,
+        )
+
+        # Without proximity
+        replayer_no_prox = DumpReplayer(self.dump, settings=make_settings(
+            **base,
+            proximity_filter_enabled=False,
+        ))
+        result_no_prox = replayer_no_prox.run()
+
+        # With proximity (tight distance)
+        replayer_prox = DumpReplayer(self.dump, settings=make_settings(
+            **base,
+            proximity_filter_enabled=True,
+            proximity_filter_distance_percentage=0.05,
+        ))
+        result_prox = replayer_prox.run()
+
+        print(f"Without proximity: {result_no_prox.total_safety_cars()} SCs")
+        print(f"With proximity (5%): {result_prox.total_safety_cars()} SCs")
+
+        # With no proximity, the 2 off-track cars at frames 13+ should trigger
+        assert result_no_prox.total_safety_cars() >= 1
+
+
+# ---------------------------------------------------------------------------
+# Test: Detection log inspection
+# ---------------------------------------------------------------------------
+
+class TestDetectionLog:
+    """Tests demonstrating how to use the detection log for debugging.
+
+    The detection log records per-frame what was detected, which is useful
+    for understanding why a SC did or didn't trigger.
+    """
+
+    dump = DUMPS_DIR / "race_weird_sc_with_lots_of_waves.ndjson"
+
+    def test_detection_log_captures_off_track_events(self):
+        """Verify the detection log records off-track drivers."""
+        replayer = DumpReplayer(self.dump, settings=make_settings(
+            off_track_detector_enabled=True,
+            off_track_cars_threshold=50,  # High threshold — no SC, just observe
+            stopped_detector_enabled=False,
+            random_detector_enabled=False,
+            proximity_filter_enabled=False,
+            race_start_threshold_multiplier=1.0,
+            event_time_window_seconds=5.0,
+            detection_start_minute=0.0,
+            detection_end_minute=60.0,
+            max_safety_cars=10,
+        ))
+        result = replayer.run()
+
+        # Find frames where off-track drivers were detected
+        frames_with_off_track = [
+            entry for entry in result.detection_log
+            if entry.off_track_drivers
+        ]
+
+        assert len(frames_with_off_track) > 0, "Expected some frames with off-track drivers"
+
+        # Check that we see the 2-car incident
+        frames_with_two_off = [
+            entry for entry in frames_with_off_track
+            if len(entry.off_track_drivers) >= 2
+        ]
+        assert len(frames_with_two_off) > 0, (
+            "Expected frames with 2+ off-track drivers (the #108/#88 incident)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regression: race_weird_sc_with_lots_of_waves (v0.5.0 bugs)
+# ---------------------------------------------------------------------------
+
+class TestRegressionWeirdScWithLotsOfWaves:
+    """Regression tests for two bugs observed during a race running v0.5.0.
+
+    The dump captures an incident where cars #108 (driver_idx=12) and #88
+    (driver_idx=14) went off-track and stopped together near lap distance ~0.08.
+
+    Bug 1 — Double-counting in accumulative threshold (fixed in ec3dfc2):
+        The old code summed weights for ALL event types per driver. A driver
+        both stopped (weight=3) and off-track (weight=2) contributed 5 to the
+        accumulative score. With 2 drivers: 2×5 = 10 >= 7 threshold → SC.
+        The fix takes only the highest weight per driver: 2×max(3,2) = 6 < 7 → no SC.
+
+    Bug 2 — Waving not-in-world cars (fixed in 597efb5):
+        11 cars with track_loc=-1 (disconnected/not_in_world) had laps_started=-1,
+        appearing "many laps behind" the class leader. They were incorrectly waved.
+        The fix filters TrkLoc.not_in_world from wave around eligibility.
+        Only 4 cars (#173, #284, #924, #257) should actually be waved.
+
+    To verify these tests would FAIL on the buggy version:
+        git stash && git checkout v0.5.0
+        pytest src/core/tests/test_e2e_detection_and_procedures.py::TestRegressionWeirdScWithLotsOfWaves -v
+        git checkout - && git stash pop
+    """
+
+    dump = DUMPS_DIR / "race_weird_sc_with_lots_of_waves.ndjson"
+
+    # Exact settings from the race log (ThresholdCheckerSettings at line 12)
+    race_settings = dict(
+        stopped_detector_enabled=True,
+        stopped_cars_threshold=3,
+        off_track_detector_enabled=True,
+        off_track_cars_threshold=4,
+        random_detector_enabled=False,
+        proximity_filter_enabled=True,
+        proximity_filter_distance_percentage=0.08,
+        event_time_window_seconds=5.0,
+        accumulative_detector_enabled=True,
+        accumulative_threshold=7.0,
+        off_track_weight=2.0,
+        stopped_weight=3.0,
+        race_start_threshold_multiplier=1.0,
+        race_start_threshold_multiplier_time_seconds=30.0,
+        detection_start_minute=0.0,
+        detection_end_minute=60.0,
+        max_safety_cars=10,
+        wave_arounds_enabled=True,
+        wave_around_rules_index=0,
+        laps_before_wave_arounds=0,
+    )
+
+    # --- Bug 1: Accumulative double-counting ---
+
+    def test_sc_not_triggered_with_no_double_count(self):
+        """With the double-count fix, the accumulative score is 6 < 7 → no SC.
+
+        Before the fix (v0.5.0): acc = 2×(2+3) = 10 >= 7 → SC triggered.
+        After the fix:           acc = 2×max(2,3) = 6  < 7 → no SC.
+        """
+        replayer = DumpReplayer(self.dump, settings=make_settings(**self.race_settings))
+        result = replayer.run()
+
+        assert result.total_safety_cars() == 0, (
+            f"Expected 0 SCs with accumulative threshold=7 and no double-counting "
+            f"(score should be 6), got {result.total_safety_cars()}"
+        )
+
+    def test_sc_triggers_at_old_accumulative_score(self):
+        """With threshold=6 (the new scoring boundary), the SC triggers.
+
+        This proves the incident IS real and detectable — only the counting
+        method changed. New score: 2×max(3,2) = 6 >= 6 → SC.
+        """
+        settings = {**self.race_settings, "accumulative_threshold": 6.0}
+        replayer = DumpReplayer(self.dump, settings=make_settings(**settings))
+        result = replayer.run()
+
+        assert result.total_safety_cars() >= 1, (
+            f"Expected at least 1 SC with accumulative threshold=6 "
+            f"(score should be exactly 6), got {result.total_safety_cars()}"
+        )
+
+    # --- Bug 2: Waving not-in-world cars ---
+
+    def test_wave_arounds_only_wave_eligible_cars(self):
+        """Only on-track lapped cars should be waved, not disconnected ones.
+
+        Before the fix (v0.5.0): 15 cars were waved, 11 of which had
+        track_loc=-1 (not_in_world) with laps_started=-1.
+        After the fix: only 4 cars (#173, #284, #924, #257) are waved.
+
+        Uses off_track_cars_threshold=2 to trigger the SC in the dump.
+        Waves are computed after the leader crosses S/F (compute_waves_after_laps=0)
+        to match the real race timing where waves fire at the next lap crossing.
+        """
+        settings = {
+            **self.race_settings,
+            "off_track_cars_threshold": 2,
+        }
+        replayer = DumpReplayer(
+            self.dump,
+            settings=make_settings(**settings),
+            compute_waves_after_laps=0,
+        )
+        result = replayer.run()
+
+        assert result.total_safety_cars() >= 1, "SC must trigger for wave around test"
+
+        waved = set(result.waved_car_numbers_for_sc(0))
+        expected = {"173", "284", "924", "257"}
+
+        assert waved == expected, (
+            f"Expected exactly {expected} to be waved, got {waved}. "
+            f"Difference: extra={waved - expected}, missing={expected - waved}"
+        )
+
+    # --- Bug 2 (cont.): Wave around timing ---
+
+    def test_wave_timing_zero_laps_fires_at_next_lap_crossing(self):
+        """With laps_before_wave_arounds=0, waves fire at the next S/F crossing.
+
+        The SC fires around frame 13-18 (when off-track threshold is met).
+        Max lap goes 15→16 at frame 34. With compute_waves_after_laps=0,
+        wave_target = lap_at_sc + 0 + 1, so waves fire when max_lap reaches
+        that target — at or after frame 34.
+        """
+        settings = {
+            **self.race_settings,
+            "off_track_cars_threshold": 2,
+        }
+        replayer = DumpReplayer(
+            self.dump,
+            settings=make_settings(**settings),
+            compute_waves_after_laps=0,
+        )
+        result = replayer.run()
+
+        assert result.total_safety_cars() >= 1, "SC must trigger for timing test"
+
+        sc = result.safety_car_events[0]
+        assert sc.wave_commands, "Expected wave commands to be computed"
+        assert sc.wave_frame_index is not None, "Expected wave_frame_index to be set"
+        assert sc.wave_frame_index > sc.frame_index, (
+            f"Waves should fire after SC (SC at frame {sc.frame_index}, "
+            f"waves at frame {sc.wave_frame_index})"
+        )
+
+    def test_wave_timing_one_lap_waves_not_in_dump(self):
+        """With laps_before_wave_arounds=1, wave target lap is never reached.
+
+        Max lap only goes from 15 to 16 in the dump. With 1 extra lap wait,
+        wave_target = lap_at_sc + 1 + 1 = 17, which is never reached.
+        """
+        settings = {
+            **self.race_settings,
+            "off_track_cars_threshold": 2,
+        }
+        replayer = DumpReplayer(
+            self.dump,
+            settings=make_settings(**settings),
+            compute_waves_after_laps=1,
+        )
+        result = replayer.run()
+
+        assert result.total_safety_cars() >= 1, "SC must trigger for timing test"
+
+        sc = result.safety_car_events[0]
+        assert sc.wave_commands == [], (
+            f"Expected no wave commands with laps_before=1 (target lap not reached in dump), "
+            f"got {sc.wave_commands}"
+        )


### PR DESCRIPTION
# Description

This adds a test util we can leverage to replay SDK dump files and validate our changes against recorded situations.

Also adds regression tests for the recently observed SC trigger and procedures that we fixed in #122 and #123. Note that these tests will fail if we do not merge those PRs first (as designed).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

`pytest` to run it all, but in this case I also explicitly used AI to run the regression tests on `v0.5.0` to validate that our recent fixes resolved the issues (double counting for accumulative threshold and wave around for `out_of_world`). Also explicitly confirmed that the wave_around_laps setting at 0 caused the wave arounds to be sent so early.

```
 - All 15 e2e tests pass on the current branch (13 pass on main without PRs #122/#123)
  - Regression tests validated against v0.5.0 — both test_sc_not_triggered_with_no_double_count and test_wave_arounds_only_wave_eligible_cars fail as
  expected on the buggy version
```

## Checklist

- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes (NOTE 2 tests depend on PRs #122/#123)

## Documentation Updates

Please check the boxes below if your changes affect these documentation files:

- [x] Updated [.ai-context.md](../.ai-context.md) if adding new patterns or conventions
- [ ] Updated [ARCHITECTURE.md](../ARCHITECTURE.md) if changing system design or workflows
- [ ] Updated [.ai-modules.md](../.ai-modules.md) if adding new modules or changing module responsibilities
- [ ] Updated [README.md](../README.md) if changing user-facing features or setup instructions
- [ ] Updated [docs/RACING_CONCEPTS.md](../docs/RACING_CONCEPTS.md) if adding new racing concepts or terminology
- [ ] No documentation updates needed