### PR TITLE
[AI] Add dev shortcuts to build output

### DIFF
--- a/build.py
+++ b/build.py
@@ -181,6 +181,31 @@ class Builder:
             except Exception as e:
                 print(f"Error copying {src_path} to {dest_path}: {e}")
 
+    def create_dev_shortcuts(self):
+        """Create a 'dev' folder with Windows batch file shortcuts for dev mode."""
+        print("Creating dev shortcuts...")
+        dev_dir = self.dist_dir / "dev"
+        dev_dir.mkdir(parents=True, exist_ok=True)
+
+        exe_relative_path = f"..\\{self.exe_name}.exe"
+
+        # Shortcut for --developer-mode
+        dev_bat = dev_dir / f"{self.exe_name}-dev.bat"
+        dev_bat.write_text(
+            f"@echo off\r\n"
+            f"start \"\" \"%~dp0{exe_relative_path}\" -dev\r\n"
+        )
+
+        # Shortcut for --dry-run --developer-mode
+        dry_dev_bat = dev_dir / f"{self.exe_name}-dry-dev.bat"
+        dry_dev_bat.write_text(
+            f"@echo off\r\n"
+            f"start \"\" \"%~dp0{exe_relative_path}\" -dry -dev\r\n"
+        )
+
+        print(f"  Created: {dev_bat.name}")
+        print(f"  Created: {dry_dev_bat.name}")
+
     def create_zip_archive(self):
         """Create a ZIP archive of the distribution directory."""
         if not self.args.zip:
@@ -222,6 +247,7 @@ class Builder:
         self.install_dependencies()
         self.create_executable()
         self.copy_assets()
+        self.create_dev_shortcuts()
 
         # List files in dist directory to verify contents
         print("\nVerifying build contents:")


### PR DESCRIPTION

# Description
                                                                                                                                                      
  - Add a `dev/` folder to the build output containing Windows batch file shortcuts for common developer workflows
  - `iRSCG-dev.bat` — launches the app with `--developer-mode` (`-dev`)
  - `iRSCG-dry-dev.bat` — launches the app with `--dry-run --developer-mode` (`-dry -dev`)
  - Shortcuts use relative paths so they work from the extracted distribution without modification

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

  - [ ] Run `python build.py` and verify the `dev/` folder is created in the dist directory
  - [ ] Verify both `.bat` files contain the correct relative path and flags
  - [ ] Run each `.bat` file on Windows and confirm the app launches with the expected mode

## Checklist

- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- N/A: I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Documentation Updates

Please check the boxes below if your changes affect these documentation files:

- [ ] Updated [.ai-context.md](../.ai-context.md) if adding new patterns or conventions
- [ ] Updated [ARCHITECTURE.md](../ARCHITECTURE.md) if changing system design or workflows
- [ ] Updated [.ai-modules.md](../.ai-modules.md) if adding new modules or changing module responsibilities
- [ ] Updated [README.md](../README.md) if changing user-facing features or setup instructions
- [ ] Updated [docs/RACING_CONCEPTS.md](../docs/RACING_CONCEPTS.md) if adding new racing concepts or terminology
- [x] No documentation updates needed