### PR TITLE
Run detectors when event type threshold is disabled but weight > 0

### DIFF
--- a/.ai-context.md
+++ b/.ai-context.md
@@ -115,25 +115,27 @@ class SupportsDetect(Protocol):
 The composite Detector is constructed via a builder:
 
 ```python
-# src/core/detection/detector.py:35-50
+# src/core/detection/detector.py — build_detector()
 @staticmethod
-def build_detector(settings: DetectorSettings, drivers: Drivers) -> "Detector":
-    """Build detector with enabled sub-detectors based on settings."""
-    detectors: list[SupportsDetect] = []
+def build_detector(settings: DetectorSettings, drivers: Drivers):
+    """Build detector with enabled sub-detectors based on settings.
 
-    if settings.random_detector_enabled:
-        detectors.append(RandomDetector(settings.random_detector_settings))
+    Each detector is instantiated if individually enabled OR if its
+    accumulative weight is non-zero (so it contributes to weighted thresholds).
+    """
+    detectors = {}
 
-    if settings.stopped_detector_enabled:
-        detectors.append(StoppedDetector(drivers, settings.stopped_detector_settings))
+    if settings.stopped_detector_enabled or settings.accumulative_weights.get(DetectorEventTypes.STOPPED, 0) > 0:
+        detectors[DetectorEventTypes.STOPPED] = StoppedDetector(drivers)
 
-    if settings.off_track_detector_enabled:
-        detectors.append(OffTrackDetector(drivers, settings.off_track_detector_settings))
+    if settings.off_track_detector_enabled or settings.accumulative_weights.get(DetectorEventTypes.OFF_TRACK, 0) > 0:
+        detectors[DetectorEventTypes.OFF_TRACK] = OffTrackDetector(drivers)
 
+    # ... same pattern for other detectors
     return Detector(detectors)
 ```
 
-**When to modify:** Add new detector types to the builder when creating new detection algorithms.
+**When to modify:** Add new detector types to the builder when creating new detection algorithms. Remember to check both the `_enabled` flag and `accumulative_weights` for the new event type.
 
 ### 5. Factory Pattern
 
@@ -457,6 +459,7 @@ def clean_up_events(self, current_time: float):
 - Events expire after `time_range` seconds (default: 5s)
 - Per-driver tracking prevents double-counting
 - Supports both per-event-type and accumulative (weighted) thresholds
+- `individually_enabled_event_types` gates per-event-type threshold checks — detectors running only for accumulative weight contribution skip individual threshold evaluation
 - Dynamic threshold multipliers during race start period
 
 ### Proximity Clustering
@@ -503,7 +506,7 @@ def detect(self) -> BundledDetectedEvents:
 2. Add event type to `DetectorEventTypes` enum in `detector_common_types.py`
 3. Add settings dataclass for your detector
 4. Update `DetectorSettings` dataclass with your detector's enabled flag and settings
-5. Update `Detector.build_detector()` to instantiate your detector
+5. Update `Detector.build_detector()` to instantiate your detector — check both the `_enabled` flag and `accumulative_weights` for the new event type
 6. Add threshold settings to `ThresholdCheckerSettings`
 7. Create tests in `src/core/detection/tests/test_your_detector.py`
 

--- a/.ai-modules.md
+++ b/.ai-modules.md
@@ -87,6 +87,7 @@ Quick reference for module responsibilities, dependencies, and when to modify ea
 
 **Key Classes:**
 - `Detector` - Composite pattern coordinator with builder via `build_detector()`. See `.ai-context.md` for builder and protocol patterns.
+- `DetectorSettings` - Configuration dataclass including `accumulative_weights` dict — used by `build_detector()` to instantiate detectors that are individually disabled but have non-zero accumulative weight.
 
 **Key Methods:** `build_detector()`, `detect()`, `race_started()`
 
@@ -129,6 +130,9 @@ Quick reference for module responsibilities, dependencies, and when to modify ea
 **Role:** Event aggregation with sliding time window and threshold checking
 
 **Key Methods:** `register_detection_result()`, `clean_up_events()`, `threshold_met()`
+
+**Key Settings Fields:**
+- `ThresholdCheckerSettings` includes `individually_enabled_event_types` (set) — per-event-type threshold checks are skipped for detectors not in this set, so detectors running only for accumulative weight don't trigger individual thresholds.
 
 See `.ai-context.md` for sliding window algorithm details and proximity clustering.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,3 +34,8 @@ Read these files for full project context:
 ## Documentation Updates
 
 After implementing changes, **always review and update** the documentation files listed above (plus `README.md` and this file) when relevant. See the Post-Implementation Checklist in `.ai-context.md` for the full list and criteria. Skipping documentation updates causes knowledge drift.
+
+## Planning Requirements
+
+Every plan MUST include a final step: "Review and update documentation" referencing
+the Post-Implementation Checklist in `.ai-context.md`. Do not skip this step.

--- a/src/core/tests/test_e2e_detection_and_procedures.py
+++ b/src/core/tests/test_e2e_detection_and_procedures.py
@@ -618,6 +618,8 @@ class TestMeatballDetection:
             stopped_detector_enabled=False,
             off_track_detector_enabled=False,
             random_detector_enabled=False,
+            stopped_weight=0.0,
+            off_track_weight=0.0,
             proximity_filter_enabled=False,
             race_start_threshold_multiplier=1.0,
             event_time_window_seconds=5.0,

--- a/src/core/tests/test_generator_detector_integration.py
+++ b/src/core/tests/test_generator_detector_integration.py
@@ -350,22 +350,25 @@ class TestGeneratorDetectorEndToEndIntegration:
         assert threshold_spy.call_count > 0
 
     def test_detector_settings_disabled_detectors_not_called(self, generator_with_mocks, mock_drivers, mocker):
-        """Test that disabled detectors are not included in the detector."""
+        """Test that disabled detectors with zero weight are not included in the detector."""
         generator = generator_with_mocks
 
-        # Disable some detectors in settings
+        # Disable some detectors in settings AND zero out their weights
         generator.master.settings.random_detector_enabled = False
         generator.master.settings.off_track_detector_enabled = False
-        
+        generator.master.settings.off_track_weight = 0.0
+
         generator.drivers = mock_drivers
-        
+
         # Initialize detector with disabled settings
         detector_settings = DetectorSettings.from_settings(generator.master.settings)
         generator.detector = Detector.build_detector(detector_settings, mock_drivers)
-        
-        # Check that only stopped detector is enabled
+
+        # Stopped is enabled, so it should be present
         assert DetectorEventTypes.STOPPED in generator.detector.detectors
+        # Random is disabled with weight 0 (always), so not present
         assert DetectorEventTypes.RANDOM not in generator.detector.detectors
+        # Off-track is disabled AND weight is 0, so not present
         assert DetectorEventTypes.OFF_TRACK not in generator.detector.detectors
 
 


### PR DESCRIPTION
# Description

 `Detector.build_detector()` only instantiates detectors when their `*_detector_enabled` flag is True. If a user disables e.g. `stopped_detector_enabled` but sets `stopped_weight > 0`, stopped events are never detected and never contribute to the accumulative score.

This will make sure that if either is true, the detector will run but the results will only be used for the individual threshold check if it was enabled.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing

`pytest`

## Checklist

- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.md](../CONTRIBUTING.md))
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing tests pass locally with my changes

## Documentation Updates

Please check the boxes below if your changes affect these documentation files:

- [x] Updated [ARCHITECTURE.md](../ARCHITECTURE.md) if changing system design, components, data flow, or workflows
- [x] Updated [.ai-modules.md](../.ai-modules.md) if adding/removing modules or changing module responsibilities/dependencies
- [x] Updated [.ai-context.md](../.ai-context.md) if adding new patterns, conventions, or gotchas
- [x] Updated [CLAUDE.md](../CLAUDE.md) if changing commands, context files, or workflow instructions
- [ ] Updated [CONTRIBUTING.md](../CONTRIBUTING.md) if changing development setup, commit conventions, or PR process
- [ ] Updated [README.md](../README.md) if changing user-facing features, setup instructions, or configuration
- [ ] Updated [docs/RACING_CONCEPTS.md](../docs/RACING_CONCEPTS.md) if adding new racing concepts or domain terminology
- [ ] No documentation updates needed